### PR TITLE
Pass the action token to reviewdog

### DIFF
--- a/donotsubmit/action.yaml
+++ b/donotsubmit/action.yaml
@@ -19,6 +19,8 @@ runs:
 
   - name: Do Not Submit
     shell: bash
+    env:
+      REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
     run: |
       set -e
       cd "${GITHUB_WORKSPACE}" || exit 1


### PR DESCRIPTION
I didn't think this was needed for PRs, but it is even though it is powerless.