### PR TITLE
add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,55 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # github-actions / path starts .github/workflows
+    directory: "/../../boilerplate"
+    schedule:
+      # Run every weekday
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../donotsubmit"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../eof-newline"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../gofmt"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../goimports"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../kind-diag"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../nodiff"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../setup-kind"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../setup-knative"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../setup-mink"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../setup-mirror"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/../../trailing-space"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
dependabot directory does not support wildcard.
need to list each one separately.

Signed-off-by: Kenny Leung <kleung@chainguard.dev>