### PR TITLE
run action lint on all yaml files.

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-
-      - name: Action lint
-        uses: reviewdog/action-actionlint@v1
+      - id: get_yamls
+        run: |
+          yamls=$(find . -name "*.yaml")
+          echo "::set-output name=files::${yamls}"
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          actionlint_flags: ${{ steps.get_yamls.outputs.files }}


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

Tweak action to run lint on all yaml files.
mirrors https://github.com/knative/actions/commit/5ed5e1fa5ae4af2da1459e70fca5408939f72f04