### PR TITLE
Plumb the invite code through from the caller

### DIFF
--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -17,6 +17,10 @@ and authenticates with it using identity tokens.
     # (for now).
     # Required.
     audience: oscar-the-grouch
+    # invite-code is an invitation code that may be used to have this workload
+    # register itself with the Chainguard API the first time it executes.
+    # Optional.
+    invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
 ```
 
 ## Scenarios
@@ -30,4 +34,5 @@ steps:
   with:
     environment: big-bird
     audience: elmo
+    invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
 ```

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -20,6 +20,13 @@ inputs:
       and has no default (for now).
     required: true
 
+  invite-code:
+    description: |
+      Optionally specifies an invite code that allows this workflow
+      register itself when run for the first time.
+    required: false
+
+
 runs:
   using: "composite"
 
@@ -34,7 +41,7 @@ runs:
     - name: Authenticate with Chainguard
       shell: bash
       env:
-        CHAINGUARD_INVITE_CODE: ${{ secrets.CHAINGUARD_INVITE_CODE }}
+        CHAINGUARD_INVITE_CODE: ${{ inputs.invite-code }}
       run: |
         AUDIENCE="${{ inputs.audience }}"
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')


### PR DESCRIPTION
Actions doesn't like the composite workflow accessing secrets.