### PR TITLE
compress kind logs

### DIFF
--- a/kind-diag/action.yaml
+++ b/kind-diag/action.yaml
@@ -21,7 +21,7 @@ inputs:
       to describe and dump.
     required: true
     default: pods
-    
+
   artifact-name:
     description: |
       The name of the artifact to upload.
@@ -60,11 +60,13 @@ runs:
     - name: Collect logs
       shell: bash
       run: |
-        mkdir -p /tmp/logs
-        kind export logs /tmp/logs
+        mkdir -p /tmp/${{ inputs.artifact-name }}
+        kind export logs /tmp/${{ inputs.artifact-name }}
+        tar -zcf /tmp/${{ inputs.artifact-name }}.tar.gz -C /tmp ${{ inputs.artifact-name }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ inputs.artifact-name }}
-        path: /tmp/logs
+        name: ${{ inputs.artifact-name }}.tar.gz
+        path: /tmp/${{ inputs.artifact-name }}.tar.gz
+


### PR DESCRIPTION
In my kind clusters I have auditing turned on and this change reduces file sizes from 1G => 60mb

Some things to note from: https://github.com/actions/upload-artifact#zipped-artifact-downloads

> During a workflow run, files are uploaded and downloaded individually using the upload-artifact and download-artifact actions. However, when a workflow run finishes and an artifact is downloaded from either the UI or through the [download api](https://developer.github.com/v3/actions/artifacts/#download-an-artifact), a zip is dynamically created with all the file contents that were uploaded. There is currently no way to download artifacts after a workflow run finishes in a format other than a zip or to download artifact contents individually. One of the consequences of this limitation is that if a zip is uploaded during a workflow run and then downloaded from the UI, there will be a double zip created.

And this tidbit under https://github.com/actions/upload-artifact#where-does-the-upload-go

> Billing is based on the raw uploaded size and not the size of the zip.