### PR TITLE
melange-build: fix signing-key-path to use github.workspace

### DIFF
--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -25,7 +25,7 @@ inputs:
   signing-key-path:
     description: |
       The path for the temporary key if signing is enabled.
-    default: /root/melange.rsa
+    default: ${{ github.workspace }}/melange.rsa
 
 runs:
   using: 'composite'


### PR DESCRIPTION
One last rootless fix...