### PR TITLE
apko-build: add archs and keyring-append options

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -32,6 +32,11 @@ inputs:
       The value to pass to --image-refs.
     default: /tmp/apko.images
 
+  keyring-append:
+    description: |
+      The value to pass to --keyring-append.
+    default: ''
+
 outputs:
   digest:
     description: |
@@ -51,6 +56,7 @@ runs:
     - |
       set -o errexit
 
-      /ko-app/apko publish --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }}
+      [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
+      /ko-app/apko publish --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat "${{ inputs.image_refs }}")

--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -37,6 +37,11 @@ inputs:
       The value to pass to --keyring-append.
     default: ''
 
+  archs:
+    description: |
+      The architectures to build for.
+    default: ''
+
 outputs:
   digest:
     description: |
@@ -57,6 +62,7 @@ runs:
       set -o errexit
 
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
-      /ko-app/apko publish --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys
+      [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
+      /ko-app/apko publish --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat "${{ inputs.image_refs }}")


### PR DESCRIPTION
These are needed for customizing apko behavior at image build time.