### PR TITLE
add action to setup monitoring stack

### DIFF
--- a/setup-monitoring/README.md
+++ b/setup-monitoring/README.md
@@ -1,0 +1,31 @@
+# Setup Monitoring Stack (Prometheus / Grafana)
+
+This action spins up a Monitoring Stack (Prometheus / Grafana) with a Grafana Render backend to export the dashboards as png.
+You need a running KinD cluster before using this action
+
+## Usage
+
+```yaml
+- uses: chainguard-dev/actions/setup-monitoring@main
+  with:
+    # Helm version to be installed
+    # Optional.
+    helm-version: v3.8.1
+    # Helm chart version to be installed can be found here
+    # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml
+    # Optional.
+    prometheus-chart-version: 34.5.1
+    # In which namespace the stack will be deployed (default monitoring-system)
+    # Optional.
+    monitoring-namespace: monitoring-system
+```
+
+## Scenarios
+
+```yaml
+steps:
+- uses: chainguard-dev/actions/setup-kind@main
+  with:
+    k8s-version: 1.22.x
+- uses: chainguard-dev/actions/setup-monitoring@main
+```

--- a/setup-monitoring/action.yaml
+++ b/setup-monitoring/action.yaml
@@ -1,0 +1,46 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup Monitoring'
+description: |
+  This action sets up the Prometheus Stack using the Helm chart using the basic configuration
+  (https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
+
+inputs:
+  helm-version:
+    description: |
+      Helm version to install (default v3.8.1)
+    required: false
+    default: v3.8.1
+
+  prometheus-chart-version:
+    description: |
+      kube-prometheus-stack helm chart version to be installed (default 34.5.1)
+    required: false
+    default: 34.5.1
+
+  monitoring-namespace:
+    description: |
+      In which namespace the stack will be deployed (default monitoring-system)
+    required: false
+    default: monitoring-system
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install Helm
+      uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
+      with:
+        version: ${{ inputs.helm-version }}
+
+    - name: Install Prometheus
+      shell: bash
+      run: |
+        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+        helm repo update
+        helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
+          --create-namespace -n ${{ inputs.monitoring-namespace }} \
+          -f "$GITHUB_ACTION_PATH/values.yaml" \
+          --version ${{ inputs.prometheus-chart-version }} \
+          --wait

--- a/setup-monitoring/values.yaml
+++ b/setup-monitoring/values.yaml
@@ -1,0 +1,21 @@
+kube-state-metrics:
+  metricLabelsAllowlist:
+    - pods=[*]
+    - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+
+grafana:
+  sidecar:
+    dashboards:
+      searchNamespace: ALL
+  plugins:
+    enabled: true
+  extraContainers: |
+    - name: renderer
+      image: docker.io/grafana/grafana-image-renderer:latest
+  env:
+    GF_RENDERING_SERVER_URL: http://localhost:8081/render
+    GF_RENDERING_CALLBACK_URL: http://localhost:3000/


### PR DESCRIPTION
- Add setup monitoring

That will deploy the Prometheus stack together with Grafana and setup the render backend to we be able to export the Grafana dashboards as images

Sample run: https://github.com/cpanato/testing-ci-providers/runs/6007181409?check_suite_focus=true