### PR TITLE
refactor the melange actions

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -1,0 +1,44 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Build single package with Melange'
+description: |
+  This action generates a package using Melange.  It assumes that
+  the Melange repository is already configured.
+
+inputs:
+  config:
+    description: |
+      The config file to use for building the package.
+    default: .melange.yaml
+
+  archs:
+    description: |
+      The architectures to use.
+    default: x86_64
+
+  sign-with-key:
+    description: |
+      Sign packages with a key, useful for multi-stage
+      pipelines.
+    default: false
+
+  signing-key-path:
+    description: |
+      The path for the temporary key if signing is enabled.
+    default: ${{ github.workspace }}/melange.rsa
+
+  repository-path:
+    description: |
+      The path of the repository being constructed by Melange.
+    default: ${{ github.workspace }}/packages
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: 'Build package with Melange'
+      shell: bash
+      run: |
+        ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
+        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg --use-proot

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -42,12 +42,7 @@ runs:
       run: |
         ${{ inputs.sign-with-temporary-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
         melange build ${{ inputs.config }} --arch ${{ inputs.archs }} $signarg --use-proot
-    - name: 'Index packages'
-      shell: bash
-      run: |
-        for arch in $(echo ${{ inputs.archs }} | tr "," " "); do
-          pushd packages/$arch
-          apk index -o APKINDEX.tar.gz *.apk
-          ${{ inputs.sign-with-temporary-key }} && melange sign-index --signing-key=${{ inputs.signing-key-path }} APKINDEX.tar.gz
-          popd
-        done
+    - uses: chainguard-dev/actions/melange-index@main
+      with:
+        sign-with-key: ${{ inputs.sign-with-temporary-key }}
+        signing-key-path: ${{ inputs.signing-key-path }}

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -29,12 +29,16 @@ inputs:
       The path for the temporary key if signing is enabled.
     default: ${{ github.workspace }}/melange.rsa
 
+  repository-path:
+    description: |
+      The path of the repository being constructed by Melange.
+    default: ${{ github.workspace }}/packages
+
 runs:
   using: 'composite'
 
   steps:
     - uses: chainguard-dev/actions/setup-melange@main
-    # TODO(kaniini): enable keyless signing once it lands
     - uses: chainguard-dev/actions/melange-keygen@main
       if: ${{ inputs.sign-with-temporary-key }}
       with:
@@ -45,8 +49,10 @@ runs:
         archs: ${{ inputs.archs }}
         sign-with-key: ${{ inputs.sign-with-temporary-key }}
         signing-key-path: ${{ inputs.signing-key-path }}
+        repository-path: ${{ inputs.repository-path }}
     - uses: chainguard-dev/actions/melange-index@main
       with:
         archs: ${{ inputs.archs }}
         sign-with-key: ${{ inputs.sign-with-temporary-key }}
         signing-key-path: ${{ inputs.signing-key-path }}
+        repository-path: ${{ inputs.repository-path }}

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -3,7 +3,9 @@
 
 name: 'Build package with melange'
 description: |
-  This action builds a package using Melange, given a config file.
+  This action builds a single package using Melange, given a config file.
+  It deals with setting up the Melange build tool, repository, and signing
+  key.
 
 inputs:
   config:
@@ -37,12 +39,14 @@ runs:
       if: ${{ inputs.sign-with-temporary-key }}
       with:
         signing-key-path: ${{ inputs.signing-key-path }}
-    - name: 'Build package with Melange'
-      shell: bash
-      run: |
-        ${{ inputs.sign-with-temporary-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
-        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} $signarg --use-proot
+    - uses: chainguard-dev/actions/melange-build-pkg@main
+      with:
+        config: ${{ inputs.config }}
+        archs: ${{ inputs.archs }}
+        sign-with-key: ${{ inputs.sign-with-temporary-key }}
+        signing-key-path: ${{ inputs.signing-key-path }}
     - uses: chainguard-dev/actions/melange-index@main
       with:
+        archs: ${{ inputs.archs }}
         sign-with-key: ${{ inputs.sign-with-temporary-key }}
         signing-key-path: ${{ inputs.signing-key-path }}

--- a/melange-index/action.yaml
+++ b/melange-index/action.yaml
@@ -1,0 +1,42 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Index packages with Melange'
+description: |
+  This action generates a Melange repository index.
+
+inputs:
+  archs:
+    description: |
+      The architectures to use.
+    default: x86_64
+
+  sign-with-key:
+    description: |
+      Sign packages with a key, useful for multi-stage
+      pipelines.
+    default: false
+
+  signing-key-path:
+    description: |
+      The path for the temporary key if signing is enabled.
+    default: ${{ github.workspace }}/melange.rsa
+
+  repository-path:
+    description: |
+      The path of the repository being constructed by Melange.
+    default: ${{ github.workspace }}/packages
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: 'Index packages with Melange'
+      shell: bash
+      run: |
+        for arch in $(echo ${{ inputs.archs }} | tr "," " "); do
+          pushd ${{ inputs.repository-path }}/$arch
+          apk index -o APKINDEX.tar.gz *.apk
+          ${{ inputs.sign-with-key }} && melange sign-index --signing-key=${{ inputs.signing-key-path }} APKINDEX.tar.gz
+          popd
+        done


### PR DESCRIPTION
This splits up the `melange-build` pipeline into multiple composable actions.  That allows for more complex pipelines to be built (like building multiple packages in a CI run).

This will be used to support bootstrapping our Linux distribution.