### PR TITLE
melange actions: add repository-append and keyring-append inputs

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -33,6 +33,18 @@ inputs:
       The path of the repository being constructed by Melange.
     default: ${{ github.workspace }}/packages
 
+  repository-append:
+    description: |
+      A list of paths or URIs of repositories that should be
+      implicitly included in the build environment.
+    default: ''
+
+  keyring-append:
+    description: |
+      A list of paths or URIs of keys that should be included
+      in the build environment.
+    default: ''
+
 runs:
   using: 'composite'
 
@@ -40,5 +52,7 @@ runs:
     - name: 'Build package with Melange'
       shell: bash
       run: |
+        [ -n '${{ inputs.repository-append }}' ] && repoarg="--repository-append ${{ inputs.repository-append }}"
+        [ -n '${{ inputs.keyring-append }}' ] && keyringarg="--keyring-append ${{ inputs.keyring-append }}"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
-        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg --use-proot
+        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg --use-proot

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -34,6 +34,18 @@ inputs:
       The path of the repository being constructed by Melange.
     default: ${{ github.workspace }}/packages
 
+  repository-append:
+    description: |
+      A list of paths or URIs of repositories that should be
+      implicitly included in the build environment.
+    default: ''
+
+  keyring-append:
+    description: |
+      A list of paths or URIs of keys that should be included
+      in the build environment.
+    default: ''
+
 runs:
   using: 'composite'
 
@@ -50,6 +62,8 @@ runs:
         sign-with-key: ${{ inputs.sign-with-temporary-key }}
         signing-key-path: ${{ inputs.signing-key-path }}
         repository-path: ${{ inputs.repository-path }}
+        repository-append: ${{ inputs.repository-append }}
+        keyring-append: ${{ inputs.keyring-append }}
     - uses: chainguard-dev/actions/melange-index@main
       with:
         archs: ${{ inputs.archs }}


### PR DESCRIPTION
Needed to deal with `${{ github.workspace }}` among other things.