### PR TITLE
melange-keygen: use github workspace path for key storage

### DIFF
--- a/melange-keygen/action.yaml
+++ b/melange-keygen/action.yaml
@@ -10,7 +10,7 @@ inputs:
   signing-key-path:
     description: |
       The path to put the signing key at.
-    default: '/root/melange.rsa'
+    default: ${{ github.workspace }}/melange.rsa
 
   install-public-key:
     description: |


### PR DESCRIPTION
Allows package building to be simplified slightly.