### PR TITLE
melange-build: add workspace-dir option and update-index option

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -50,6 +50,11 @@ inputs:
       The directory to use as the workspace.
     default: ''
 
+  update-index:
+    description: |
+      Automatically update index when the package is built.
+    default: true
+
 runs:
   using: 'composite'
 
@@ -62,3 +67,10 @@ runs:
         [ -n '${{ inputs.workspace-dir }}' ] && workspacearg="--workspace-dir ${{ inputs.workspace-dir }}"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
         melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --use-proot
+    - uses: chainguard-dev/actions/melange-index@main
+      if: ${{ inputs.update-index }}
+      with:
+        archs: ${{ inputs.archs }}
+        repository-path: ${{ inputs.repository-path }}
+        sign-with-key: ${{ inputs.sign-with-key }}
+        signing-key-path: ${{ inputs.signing-key-path }}

--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -45,6 +45,11 @@ inputs:
       in the build environment.
     default: ''
 
+  workspace-dir:
+    description: |
+      The directory to use as the workspace.
+    default: ''
+
 runs:
   using: 'composite'
 
@@ -54,5 +59,6 @@ runs:
       run: |
         [ -n '${{ inputs.repository-append }}' ] && repoarg="--repository-append ${{ inputs.repository-append }}"
         [ -n '${{ inputs.keyring-append }}' ] && keyringarg="--keyring-append ${{ inputs.keyring-append }}"
+        [ -n '${{ inputs.workspace-dir }}' ] && workspacearg="--workspace-dir ${{ inputs.workspace-dir }}"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
-        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg --use-proot
+        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --use-proot


### PR DESCRIPTION
These are helpful for building multiple packages in a single GHA run.