### PR TITLE
digestabot: Add gitsign commit signing.

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -44,6 +44,9 @@ runs:
         echo ::set-output name=create_pr::true
       fi
 
+  # Configure signed commits
+  - uses: ./setup-gitsign
+  
   - name: Create Pull Request
     uses: peter-evans/create-pull-request@v4.0.2
     if: ${{ steps.create_pr.outputs.create_pr == 'true' }}


### PR DESCRIPTION
Configures the action to use https://github.com/sigstore/gitsign,
which means that the action will self-sign any commits it produces
with the action's own OIDC identity. 🎉

Signed-off-by: Billy Lynch <billy@chainguard.dev>