### PR TITLE
we dont checkout the actions repo, so we need to use as a common action

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -45,8 +45,8 @@ runs:
       fi
 
   # Configure signed commits
-  - uses: ./setup-gitsign
-  
+  - uses: chainguard-dev/actions/setup-gitsign@main
+
   - name: Create Pull Request
     uses: peter-evans/create-pull-request@v4.0.2
     if: ${{ steps.create_pr.outputs.create_pr == 'true' }}


### PR DESCRIPTION
from the job
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/mono/mono/setup-gitsign'. Did you forget to run actions/checkout before running your local action?

```