### PR TITLE
changes to melange actions

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -55,6 +55,11 @@ inputs:
       Automatically update index when the package is built.
     default: true
 
+  empty-workspace:
+    description: |
+      Whether to use an empty workspace or not.
+    default: false
+
 runs:
   using: 'composite'
 
@@ -65,6 +70,7 @@ runs:
         [ -n '${{ inputs.repository-append }}' ] && repoarg="--repository-append ${{ inputs.repository-append }}"
         [ -n '${{ inputs.keyring-append }}' ] && keyringarg="--keyring-append ${{ inputs.keyring-append }}"
         [ -n '${{ inputs.workspace-dir }}' ] && workspacearg="--workspace-dir ${{ inputs.workspace-dir }}"
+        ${{ inputs.empty-workspace }} && workspacearg="$workspacearg --empty-workspace"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
         melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --use-proot
     - uses: chainguard-dev/actions/melange-index@main

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -46,6 +46,11 @@ inputs:
       in the build environment.
     default: ''
 
+  empty-workspace:
+    description: |
+      Whether to use an empty workspace or not.
+    default: false
+
 runs:
   using: 'composite'
 
@@ -64,6 +69,7 @@ runs:
         repository-path: ${{ inputs.repository-path }}
         repository-append: ${{ inputs.repository-append }}
         keyring-append: ${{ inputs.keyring-append }}
+        empty-workspace: ${{ inputs.empty-workspace }}
     - uses: chainguard-dev/actions/melange-index@main
       with:
         archs: ${{ inputs.archs }}

--- a/setup-melange/action.yaml
+++ b/setup-melange/action.yaml
@@ -40,7 +40,9 @@ runs:
       shell: bash
       run: |
         git clone https://github.com/chainguard-dev/melange
-        cd melange
+        pushd melange
         make melange
         sudo env "PATH=$PATH" make install
         melange version
+        popd
+        rm -rf ./melange

--- a/setup-melange/action.yaml
+++ b/setup-melange/action.yaml
@@ -15,6 +15,7 @@ runs:
         wget 'https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/apk-tools-static-2.12.9-r3.apk'
         tar zxf apk-tools-static-2.12.9-r3.apk sbin/apk.static
         sudo mv sbin/apk.static /sbin/apk
+        rm apk-tools-static-2.12.9-r3.apk
     - name: 'Set up apk-tools in overlay mode'
       shell: bash
       run: |


### PR DESCRIPTION
* `setup-melange`: clean up after ourselves once melange is installed
* `melange-build`, `melange-build-pkg`: add support for melange `--empty-workspace`