### PR TITLE
bump gitsign action to use 0.1.0

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -12,7 +12,7 @@ runs:
         set -ex
 
         # Install
-        curl -fsL https://github.com/sigstore/gitsign/releases/download/v0.0.2-alpha/gitsign_0.0.2-alpha_linux_amd64 -o /usr/local/bin/gitsign
+        curl -fsL https://github.com/sigstore/gitsign/releases/download/v0.1.0/gitsign_0.1.0_linux_amd64 -o /usr/local/bin/gitsign
         chmod +x /usr/local/bin/gitsign
 
         # Configure


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>