### PR TITLE
Add k8s version 1.24 as an option, update others to latest. Update kind to 0.14.0

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -9,15 +9,15 @@ description: |
 inputs:
   k8s-version:
     description: |
-      The minor version of Kubernetes to use in the form: 1.23.x
+      The version of Kubernetes to use in the form: 1.23.x
     required: true
-    default: 1.21.x
+    default: 1.22.x
 
   kind-version:
     description: |
-      The exact version of KinD to use in the form: 0.11.1
+      The exact version of KinD to use in the form: 0.14.0
     required: true
-    default: 0.12.0
+    default: 0.14.0
 
   registry-authority:
     description: |
@@ -83,18 +83,23 @@ runs:
         case ${{ inputs.k8s-version }} in
 
           v1.21.x)
-            KIND_IMAGE_SHA="sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c"
-            echo "KIND_IMAGE=kindest/node:v1.21.10@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
+            KIND_IMAGE_SHA="sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207"
+            echo "KIND_IMAGE=kindest/node:v1.21.12@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
             ;;
 
           v1.22.x)
-            KIND_IMAGE_SHA="sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166"
-            echo "KIND_IMAGE=kindest/node:v1.22.7@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
+            KIND_IMAGE_SHA="sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105"
+            echo "KIND_IMAGE=kindest/node:v1.22.9@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
             ;;
 
           v1.23.x)
-            KIND_IMAGE_SHA="sha256:1a72748086bc24ed6163de1d1e33cc0e2eb5a1eb5ebffdb15b53c3bcd5376a6f"
-            echo "KIND_IMAGE=kindest/node:v1.23.5@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
+            KIND_IMAGE_SHA="sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
+            echo "KIND_IMAGE=kindest/node:v1.23.6@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
+            ;;
+
+          v1.24.x)
+            KIND_IMAGE_SHA="sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e"
+            echo "KIND_IMAGE=kindest/node:v1.24.0@${KIND_IMAGE_SHA}" >> $GITHUB_ENV
             ;;
 
           *) echo "Unsupported version: ${{ inputs.k8s-version }}"; exit 1 ;;


### PR DESCRIPTION
 * Add support for k8s version 1.24.
 * Make 1.22 the default instead of 1.21.
 * Update all kind images to latest versions.
 * Update kind to 0.14.0

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>