### PR TITLE
Use latest knative (1.5.0) by default.

### DIFF
--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -9,9 +9,9 @@ description: |
 inputs:
   version:
     description: |
-      The minor version of Knative to install, e.g. 1.2.0
+      The version of Knative to install, e.g. 1.5.0
     required: true
-    default: 1.2.0
+    default: 1.5.0
 
   kingress:
     description: |


### PR DESCRIPTION
* Bump Knative default to 1.5.0
* Note that v1.4.0 required k8s v1.22 so also made the default in #94 for k8s be 1.22 so that defaults provide a supported system.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>