### PR TITLE
Install qemu-user-static when setting up melange for arm64 packages

### DIFF
--- a/setup-melange/action.yaml
+++ b/setup-melange/action.yaml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install -y build-essential git bubblewrap proot
+        sudo apt install -y build-essential git bubblewrap proot qemu-user-static
     - name: 'Install melange'
       shell: bash
       run: |


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>