### PR TITLE
New action to generate token as a GitHub App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,windows,linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,windows,linux

--- a/githubapp-token/README.md
+++ b/githubapp-token/README.md
@@ -1,0 +1,34 @@
+# GitHub App Token
+
+This action generates a GitHub token authenticated as a GitHub App.
+
+## Usage
+
+```yaml
+- uses: chainguard-dev/actions/githubapp-token@main
+  with:
+    # The App ID of the GitHub App.
+    # Required.
+    app_id: 123
+    # The installation against which to authenticate.
+    # Required.
+    installation_id: 456
+    # The private key of the GitHub App.
+    # Required.
+    private_key: ${{ secrets.MY_PRIVATE_KEY }}
+```
+
+## Scenarios
+
+```yaml
+steps:
+  - uses: chainguard-dev/actions/githubapp-token@main
+    id: get-token
+    with:
+      app_id: 123
+      installation_id: 456
+      private_key: ${{ secrets.MY_PRIVATE_KEY }}
+  - uses: actions/checkout@v3
+    with:
+      token: ${{ steps.get-token.outputs.token }}
+```

--- a/githubapp-token/action.yaml
+++ b/githubapp-token/action.yaml
@@ -1,0 +1,61 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Authenticate as a GitHub App
+description: |
+  This action generates a GitHub App token for a specific app and
+  installation ID. It requires having access to the app's private
+  key.
+
+inputs:
+  app_id:
+    description: |
+      The App ID of the GitHub App
+    required: true
+
+  installation_id:
+    description: |
+      The installation against which to authenticate.
+    required: true
+
+  private_key:
+    description: |
+      The private key of the GitHub App
+    required: true
+
+outputs:
+  token:
+    description: |
+      The GitHub App token.
+    value: ${{ steps.get-token.outputs.token }}
+
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/setup-node@v2
+    with:
+      node-version: 16
+  - run: npm install @octokit/app
+    shell: bash
+  - uses: actions/github-script@v6
+    id: get-token
+    name: Get GitHub App token
+    env:
+      APP_ID: ${{ inputs.app_id }}
+      INSTALLATION_ID: ${{ inputs.installation_id }}
+      PRIVATE_KEY: ${{ inputs.private_key }}
+    with:
+      script: |
+        const {App} = require('@octokit/app');
+
+        const { APP_ID, INSTALLATION_ID, PRIVATE_KEY } = process.env
+
+        const app = new App({
+          appId: +APP_ID,
+          privateKey: PRIVATE_KEY,
+        });
+        const octokit = await app.getInstallationOctokit(+INSTALLATION_ID);
+        const {token} = await octokit.auth({
+          type: "installation",
+        });
+        core.setOutput('token', token);


### PR DESCRIPTION
This is helpful when impersonating a GitHub App to complete tasks, such as automated PRs or deploying to a environment branch.