### PR TITLE
[melange-build-pkg]: run 'melange build' with sudo

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -72,7 +72,7 @@ runs:
         [ -n '${{ inputs.workspace-dir }}' ] && workspacearg="--workspace-dir ${{ inputs.workspace-dir }}"
         ${{ inputs.empty-workspace }} && workspacearg="$workspacearg --empty-workspace"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
-        melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --use-proot
+        sudo melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --use-proot
     - uses: chainguard-dev/actions/melange-index@main
       if: ${{ inputs.update-index }}
       with:


### PR DESCRIPTION
melange/apko currently need root, otherwise you get this error:

```
Error: failed to build package: unable to build workspace: unable to generate image: failed to mutate accounts: chown(0, 0) = chown /tmp/melange-guest-2288225804/root: operation not permitted
```