### PR TITLE
melange-build: do not call melange-build-pkg with update-index:true

### DIFF
--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -70,6 +70,7 @@ runs:
         repository-append: ${{ inputs.repository-append }}
         keyring-append: ${{ inputs.keyring-append }}
         empty-workspace: ${{ inputs.empty-workspace }}
+        update-index: false
     - uses: chainguard-dev/actions/melange-index@main
       with:
         archs: ${{ inputs.archs }}


### PR DESCRIPTION
Signing the index multiple times can result in the wrong checksum for the signature payload.