### PR TITLE
Add setup-hakn and setup-knative-eventing to replace setup-knative

### DIFF
--- a/setup-hakn/README.md
+++ b/setup-hakn/README.md
@@ -1,0 +1,54 @@
+# Setup Knative
+
+This action installs chainguard-dev/hakn Knative into the current kubectl context.
+
+## Usage
+
+```yaml
+- uses: chainguard-dev/actions/setup-hakn@main
+  with:
+    # Version is the version of hakn to install.
+    # For example, 1.2.0.
+    # Required.
+    version: 1.2.0
+    # Serving Features is the encoded JSON containing the features to enable
+    # in this installation of Knative Serving.
+    # For example, {"kubernetes.podspec-fieldref":"enabled"}.
+    # Required.
+    serving-features: '{}'
+    # Serving Defaults is the encoded JSON containing the default values for
+    # this installation of Knative Serving.
+    # For example, {"revision-timeout-seconds":"120"}.
+    # Required.
+    serving-defaults: '{}'
+    # Serving Autoscaler is the encoded JSON containing the autoscaler settings
+    # in this installation of Knative Serving.
+    # For example, {"min-scale":"1"}.
+    # Required.
+    serving-autoscaler: '{}'
+```
+
+## Scenarios
+
+```yaml
+steps:
+- uses: chainguard-dev/actions/setup-hakn@main
+  with:
+    version: 1.2.0
+    serving-features: >
+      {
+        "kubernetes.podspec-fieldref": "enabled",
+        "kubernetes.podspec-securitycontext": "enabled"
+      }
+    serving-defaults: >
+      {
+        "revision-timeout-seconds": "120",
+        "container-concurrency": "1"
+      }
+    serving-autoscaler: >
+      {
+        "min-scale": "2",
+        "max-scale": "3"
+      }
+
+```

--- a/setup-hakn/README.md
+++ b/setup-hakn/README.md
@@ -8,9 +8,11 @@ This action installs chainguard-dev/hakn Knative into the current kubectl contex
 - uses: chainguard-dev/actions/setup-hakn@main
   with:
     # Version is the version of hakn to install.
-    # For example, 1.2.0.
-    # Required.
-    version: 1.2.0
+    # (defaults to 1.5.0)
+    version: 1.5.0
+    # istio-version is the version of Istio to install.
+    # (defaults to 1.14.0)
+    istio-version: 1.14.0
     # Serving Features is the encoded JSON containing the features to enable
     # in this installation of Knative Serving.
     # For example, {"kubernetes.podspec-fieldref":"enabled"}.
@@ -34,7 +36,8 @@ This action installs chainguard-dev/hakn Knative into the current kubectl contex
 steps:
 - uses: chainguard-dev/actions/setup-hakn@main
   with:
-    version: 1.2.0
+    version: 1.5.0
+    istio-version: 1.14.0
     serving-features: >
       {
         "kubernetes.podspec-fieldref": "enabled",

--- a/setup-hakn/README.md
+++ b/setup-hakn/README.md
@@ -1,4 +1,4 @@
-# Setup Knative
+# Setup chainguard-dev/hakn 
 
 This action installs chainguard-dev/hakn Knative into the current kubectl context.
 

--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -1,0 +1,178 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup chainguard-dev/hakn'
+description: |
+  This action sets up chainguard-dev/hakn Knative on the current
+  kubectl context (typically KinD from setup-kind).
+
+inputs:
+  version:
+    description: |
+      The version of Knative to install, e.g. 1.5.0
+    required: true
+    default: 1.5.0
+
+  cluster-domain:
+    description: |
+      The cluster domain suffix, defaults to cluster.local
+    required: false
+    default: "cluster.local"
+
+  serving-features:
+    description: |
+      The serialized JSON for the Knative Serving features configmap
+      containing the features to be enabled, e.g.
+        {"kubernetes.podspec-fieldref":"enabled"}
+    required: true
+    default: '{}'
+
+  serving-defaults:
+    description: |
+      The serialized JSON for the Knative Serving defaults configmap
+      containing the desired default values, e.g.
+        {"revision-timeout-seconds":"120"}
+    required: true
+    default: '{}'
+
+  serving-autoscaler:
+    description: |
+      The serialized JSON for the Knative Serving autoscaling configmap
+      containing the desired settings, e.g.
+        {"min-scale":"1"}
+    required: true
+    default: '{}'
+
+outputs:
+  load-balancer-ip:
+    description: |
+      The IP of the type LoadBalancer service on which knative serves.
+    value: ${{ steps.knative.outputs.load-balancer-ip }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install Knative
+      id: knative
+      shell: bash
+      run: |
+        # Eliminates the resources blocks in a release yaml
+        function resource_blaster() {
+          local FILE="${1}"
+          local DOWNLOAD_URL="https://github.com/chainguard-dev/hakn/releases/download/v${{ inputs.version }}/${FILE}"
+
+          curl -L -s $DOWNLOAD_URL \
+            | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
+            `# Filter out empty objects that come out as {} b/c kubectl barfs` \
+            | grep -v '^{}$'
+        }
+
+        function download_istioctl() {
+          ISTIO_VERSION=1.14.0
+          ISTIO_BASE_URL="https://github.com/istio/istio/releases/download"
+          case "$(echo $RUNNER_ARCH | awk '{print tolower($0)}')" in
+          x86|x64) ARCH=amd64;;
+          arm64)   ARCH=arm64;;
+          *)
+            echo Unsupported RUNNER_ARCH \"$RUNNER_ARCH\"
+            exit -1
+            ;;
+          esac
+          case "$(echo $RUNNER_OS | awk '{print tolower($0)}')" in
+          "linux") OS=linux;;
+          "macos") OS=osx;;
+          *)
+            echo Unsupported RUNNER_OS \"$RUNNER_OS\"
+            exit -1
+            ;;
+          esac
+          ISTIO_URL=${ISTIO_BASE_URL}/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OS}-${ARCH}.tar.gz
+          wget $ISTIO_URL -O istio.tar.gz
+          tar xzf istio.tar.gz
+        }
+
+        download_istioctl
+        cat > istio-profile.yaml <<EOF
+        apiVersion: install.istio.io/v1alpha1
+        kind: IstioOperator
+        spec:
+          values:
+            global:
+              # Ideally for KinD installations we want to blow away the `resources`
+              # sections. However, doing that here will result in Istio's default which
+              # is high. Choosing some nomimal small numbers here:
+              defaultResources: &defaultResources
+                requests:
+                  cpu: 1m
+                  memory: 10Mi
+              proxy:
+                clusterDomain: ${{ inputs.cluster-domain }}
+                resources: *defaultResources
+
+          meshConfig:
+            defaultConfig:
+              terminationDrainDuration: "20s"
+
+          components:
+            ingressGateways:
+              - name: istio-ingressgateway
+                k8s: &defaultK8s
+                  hpaSpec:
+                    maxReplicas: 1
+                    minReplicas: 1
+                  resources: *defaultResources
+            pilot:
+              k8s: *defaultK8s
+        EOF
+        ./istio-${ISTIO_VERSION}/bin/istioctl install --skip-confirmation -f istio-profile.yaml
+
+        resource_blaster serving.yaml | kubectl apply --validate=false -f -
+        kubectl patch configmap/config-network \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":{"ingress.class":"istio.ingress.networking.knative.dev","autocreateClusterDomainClaims":"true"}}'
+
+        # Wait for Knative to be ready (or webhook will reject services)
+        for x in $(kubectl get deploy --namespace knative-serving -oname); do
+          kubectl rollout status --timeout 5m --namespace knative-serving $x
+        done
+
+        while ! kubectl patch configmap/config-features \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":${{ inputs.serving-features }}}'
+        do
+            echo Waiting for webhook to be up.
+            sleep 1
+        done
+
+        while ! kubectl patch configmap/config-defaults \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":${{ inputs.serving-defaults }}}'
+        do
+            echo Waiting for webhook to be up.
+            sleep 1
+        done
+
+        while ! kubectl patch configmap/config-autoscaler \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":${{ inputs.serving-autoscaler }}}'
+        do
+            echo Waiting for webhook to be up.
+            sleep 1
+        done
+
+        # Wait for hakn pods to be up and running
+        kubectl wait -n knative-serving --timeout=5m --for=condition=ready pods --all
+
+        export IP=$(kubectl get svc -n istio-system istio-ingressgateway -ojsonpath={.status.loadBalancer.ingress[0].ip})
+        echo LB IP: ${IP}
+        echo ::set-output name=load-balancer-ip::${IP}
+
+        # Required for minio
+        kubectl patch cm config-domain -n knative-serving \
+          --type merge \
+          -p "{\"data\":{\"$IP.sslip.io\":\"\"}}"

--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -10,8 +10,14 @@ inputs:
   version:
     description: |
       The version of Knative to install, e.g. 1.5.0
-    required: true
+    required: false
     default: 1.5.0
+
+  istio-version:
+    description: |
+      The version of Istio to install, e.g. 1.14.0
+    required: false
+    default: 1.14.0
 
   cluster-domain:
     description: |
@@ -24,7 +30,7 @@ inputs:
       The serialized JSON for the Knative Serving features configmap
       containing the features to be enabled, e.g.
         {"kubernetes.podspec-fieldref":"enabled"}
-    required: true
+    required: false
     default: '{}'
 
   serving-defaults:
@@ -32,7 +38,7 @@ inputs:
       The serialized JSON for the Knative Serving defaults configmap
       containing the desired default values, e.g.
         {"revision-timeout-seconds":"120"}
-    required: true
+    required: false
     default: '{}'
 
   serving-autoscaler:
@@ -40,7 +46,7 @@ inputs:
       The serialized JSON for the Knative Serving autoscaling configmap
       containing the desired settings, e.g.
         {"min-scale":"1"}
-    required: true
+    required: false
     default: '{}'
 
 outputs:
@@ -57,19 +63,8 @@ runs:
       id: knative
       shell: bash
       run: |
-        # Eliminates the resources blocks in a release yaml
-        function resource_blaster() {
-          local FILE="${1}"
-          local DOWNLOAD_URL="https://github.com/chainguard-dev/hakn/releases/download/v${{ inputs.version }}/${FILE}"
-
-          curl -L -s $DOWNLOAD_URL \
-            | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
-            `# Filter out empty objects that come out as {} b/c kubectl barfs` \
-            | grep -v '^{}$'
-        }
-
         function download_istioctl() {
-          ISTIO_VERSION=1.14.0
+          ISTIO_VERSION=${{ inputs.istio-version }}
           ISTIO_BASE_URL="https://github.com/istio/istio/releases/download"
           case "$(echo $RUNNER_ARCH | awk '{print tolower($0)}')" in
           x86|x64) ARCH=amd64;;
@@ -127,6 +122,16 @@ runs:
         EOF
         ./istio-${ISTIO_VERSION}/bin/istioctl install --skip-confirmation -f istio-profile.yaml
 
+        # Eliminates the resources blocks in a release yaml
+        function resource_blaster() {
+          local FILE="${1}"
+          local DOWNLOAD_URL="https://github.com/chainguard-dev/hakn/releases/download/v${{ inputs.version }}/${FILE}"
+
+          curl -L -s $DOWNLOAD_URL \
+            | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
+            `# Filter out empty objects that come out as {} b/c kubectl barfs` \
+            | grep -v '^{}$'
+        }
         resource_blaster serving.yaml | kubectl apply --validate=false -f -
         kubectl patch configmap/config-network \
           --namespace knative-serving \

--- a/setup-knative-eventing/README.md
+++ b/setup-knative-eventing/README.md
@@ -1,4 +1,4 @@
-# Setup Knative
+# Setup Knative Eventing
 
 This action installs Knative Eventing into the current kubectl context.
 
@@ -8,9 +8,8 @@ This action installs Knative Eventing into the current kubectl context.
 - uses: chainguard-dev/actions/setup-knative-eventing@main
   with:
     # Version is the version of Knative Eventing to install.
-    # For example, 1.2.0.
-    # Required.
-    version: 1.2.0
+    # (defaults to 1.5.0)
+    version: 1.5.0
 ```
 
 ## Scenarios
@@ -19,5 +18,5 @@ This action installs Knative Eventing into the current kubectl context.
 steps:
 - uses: chainguard-dev/actions/setup-knative-eventing@main
   with:
-    version: 1.2.0
+    version: 1.5.0
 ```

--- a/setup-knative-eventing/README.md
+++ b/setup-knative-eventing/README.md
@@ -1,0 +1,23 @@
+# Setup Knative
+
+This action installs Knative Eventing into the current kubectl context.
+
+## Usage
+
+```yaml
+- uses: chainguard-dev/actions/setup-knative-eventing@main
+  with:
+    # Version is the version of Knative Eventing to install.
+    # For example, 1.2.0.
+    # Required.
+    version: 1.2.0
+```
+
+## Scenarios
+
+```yaml
+steps:
+- uses: chainguard-dev/actions/setup-knative-eventing@main
+  with:
+    version: 1.2.0
+```

--- a/setup-knative-eventing/action.yaml
+++ b/setup-knative-eventing/action.yaml
@@ -1,0 +1,70 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup Knative Eventing'
+description: |
+  This action sets up Knative Eventing on the current
+  kubectl context (typically KinD from setup-kind).
+
+inputs:
+  version:
+    description: |
+      The version of Knative to install, e.g. 1.5.0
+    required: true
+    default: 1.5.0
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Install Knative
+      id: knative
+      shell: bash
+      run: |
+        # Eliminates the resources blocks in a release yaml
+        function resource_blaster() {
+          local FILE="${1}"
+
+          curl -L -s "https://github.com/knative/eventing/releases/download/knative-v${{ inputs.version }}/${FILE}" \
+            | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
+            `# Filter out empty objects that come out as {} b/c kubectl barfs` \
+            | grep -v '^{}$'
+        }
+
+        resource_blaster eventing-crds.yaml | kubectl apply -f -
+        resource_blaster eventing-core.yaml | kubectl apply -f -
+        resource_blaster in-memory-channel.yaml | kubectl apply -f -
+        resource_blaster mt-channel-broker.yaml | kubectl apply -f -
+
+        cat | kubectl apply -f - <<EOF
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: imc-channel
+          namespace: knative-eventing
+        data:
+          channelTemplateSpec: |
+            apiVersion: messaging.knative.dev/v1
+            kind: InMemoryChannel
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: config-br-defaults
+          namespace: knative-eventing
+        data:
+          default-br-config: |
+            # This is the cluster-wide default broker channel.
+            clusterDefault:
+              brokerClass: MTChannelBasedBroker
+              apiVersion: v1
+              kind: ConfigMap
+              name: imc-channel
+              namespace: knative-eventing
+        EOF
+
+        # Wait for Knative to be ready (or webhook will reject services)
+        for x in $(kubectl get deploy --namespace knative-eventing -oname); do
+          kubectl rollout status --timeout 5m --namespace knative-eventing $x
+        done
+

--- a/setup-knative-eventing/action.yaml
+++ b/setup-knative-eventing/action.yaml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: |
       The version of Knative to install, e.g. 1.5.0
-    required: true
+    required: false
     default: 1.5.0
 
 runs:


### PR DESCRIPTION
We are switching most of our test workflows to use `setup-hakn` + `setup-knative-eventing` instead of `setup-knative`.

Most code for `setup-knative-eventing` comes from `setup-knative` with all the serving parts stripped out. 

The plan is that, in follow up PRs:
(a) after all workflows switch over, we will delete `setup-knative`
(b) after github.com/chainguard-dev/hakn acquires Knative Eventing capacity, we will delete `setup-knative-eventing` as well and only use `setup-hakn`.

