### PR TITLE
Pass in template flag directly

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -75,10 +75,9 @@ runs:
         [ -n '${{ inputs.repository-append }}' ] && repoarg="--repository-append ${{ inputs.repository-append }}"
         [ -n '${{ inputs.keyring-append }}' ] && keyringarg="--keyring-append ${{ inputs.keyring-append }}"
         [ -n '${{ inputs.workspace-dir }}' ] && workspacearg="--workspace-dir ${{ inputs.workspace-dir }}"
-        [ -n '${{ inputs.template }}' ] && templatearg="--template '${{ inputs.template }}'"
         ${{ inputs.empty-workspace }} && workspacearg="$workspacearg --empty-workspace"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
-        sudo melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg $templatearg --use-proot
+        sudo melange build ${{ inputs.config }} --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg --template='${{ inputs.template }}' --use-proot
     - name: 'Fix local repository permissions'
       shell: bash
       run: |


### PR DESCRIPTION
This should work even when template isn't set, since it'll just be empty and ignored.
Something about setting the flag as an env var with quotes just didn't work during expansion.
I couldn't figure it out why but at least this works :/