### PR TITLE
fix bug in setup-registry

### DIFF
--- a/setup-registry/action.yaml
+++ b/setup-registry/action.yaml
@@ -15,8 +15,8 @@ runs:
   using: "composite"
 
   steps:
-    - name: Install registry
+    - name: Install and run registry
       shell: bash
-      run:
+      run: |
         go install github.com/google/go-containerregistry/cmd/registry@main
         registry --port=${{ inputs.port }}


### PR DESCRIPTION
Without this, the lines are combined to form

```
go install github.com/google/go-containerregistry/cmd/registry@main registry --port=${{inputs.path}}
```

which `go install` doesn't like very much at all.