### PR TITLE
setup-mirror: Don't assume docker daemon config exists

### DIFF
--- a/setup-mirror/action.yaml
+++ b/setup-mirror/action.yaml
@@ -20,6 +20,10 @@ runs:
       shell: bash
       run: |
         tmp=$(mktemp)
+        if [ ! -f "/etc/docker/daemon.json" ]; then
+          # Create empty config if it doesn't exist 
+          echo "{}" | sudo tee /etc/docker/daemon.json
+        fi 
         jq '."registry-mirrors" = ["https://${{ inputs.mirror }}"]' /etc/docker/daemon.json > "$tmp"
         sudo mv "$tmp" /etc/docker/daemon.json
-        sudo service docker restart
+        sudo systemctl restart docker.service


### PR DESCRIPTION
Some Ubuntu Actions images don't have an `/etc/docker/daemon.json` configuration and setup-mirror assumes this file exists. This change creates an empty file config (e.g `{}`) if none already exists.