### PR TITLE
setup-gitsign: log got/want checksum SHAs.

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -121,8 +121,8 @@ runs:
         log_info "Downloading gitsign version 'v${gitsign_version}' from https://github.com/sigstore/gitsign/releases/download/v${gitsign_version}/${gitsign_filename}"
         curl -sL https://github.com/sigstore/gitsign/releases/download/v${gitsign_version}/${gitsign_filename} -o ${gitsign_executable_name}
         shaDownloaded=$(shaprog ${gitsign_executable_name});
-        if [[ $shaDownloaded != ${expected_gitsign_version_digest} ]]; then
-          log_error "Unable to validate gitsign version: 'v${gitsign_version}'"
+        if [[ ${shaDownloaded} != ${expected_gitsign_version_digest} ]]; then
+          log_error "Unable to validate gitsign version: 'v${gitsign_version}': want ${expected_gitsign_version_digest}, got ${shaDownloaded}"
           exit 1
         fi
         chmod +x ${gitsign_executable_name}


### PR DESCRIPTION
Noticed an issue where the checksum failed, but didn't really say why:

```
INFO: Downloading gitsign version 'v0.1.1' from https://github.com/sigstore/gitsign/releases/download/v0.1.1/gitsign_0.1.1_linux_amd64
ERROR: Unable to validate gitsign version: 'v0.1.1'
Error: Process completed with exit code 1.
```

I suspect this was really caused by an issue fetching the file from GitHub, but this just adds a bit more info so we can try and see what happened if things fail.