### PR TITLE
Enable Istio `holdApplicationUntilProxyStarts` opt

### DIFF
--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -118,6 +118,7 @@ runs:
               mode: ALLOW_ANY
             defaultConfig:
               terminationDrainDuration: "20s"
+              holdApplicationUntilProxyStarts: true
 
           components:
             ingressGateways:


### PR DESCRIPTION
This option helps other container wait until the sidecar is started, so that outbound traffic isn't blocked.