### PR TITLE
Exclude the K8s API server from Istio egress

### DIFF
--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -93,7 +93,12 @@ runs:
           tar xzf istio.tar.gz
         }
 
+
         download_istioctl
+
+        # Find out the K8s API server IP address and exclude it from Istio.
+        API_SERVER_IP=$(kubectl get svc kubernetes -o jsonpath='{.spec.clusterIP}')
+
         cat > istio-profile.yaml <<EOF
         apiVersion: install.istio.io/v1alpha1
         kind: IstioOperator
@@ -110,6 +115,7 @@ runs:
               proxy:
                 clusterDomain: ${{ inputs.cluster-domain }}
                 resources: *defaultResources
+                excludeIPRanges: "${API_SERVER_IP}/32"
             sidecarInjectorWebhook:
               enableNamespacesByDefault: ${{ inputs.enable-auto-injection }}
 


### PR DESCRIPTION
This makes API server traffic completely bypass Istio sidecar. Hopefully will help with flakes where sidecar server starts later than when a Pod needs to talk to API server.

See https://istio.io/latest/docs/tasks/traffic-management/egress/egress-control/#direct-access-to-external-services.