### PR TITLE
skip testdata for digestabot

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -15,6 +15,9 @@ runs:
   - shell: bash
     run: |
       while IFS= read -r -d '' file; do
+        if [[ "$file" == *testdata* ]]; then
+          continue
+        fi
         images=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f1 | rev | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///" | tr '\n' ',' || true)
         digests=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f2 | cut -d ' ' -f1 | cut -d '"' -f1 | tr '\n' ',' || true)
         IFS=',' read -r -a images2 <<< "$images"


### PR DESCRIPTION
Skip testdata that might cause digesta-bot to fail

```
Image ghcr.io/user-a/alpine-base in file /home/runner/work/mono/mono/api-impl/fake/testdata/records.yaml does not have a tag, ignoring...
Image ghcr.io/user-b/apko in file /home/runner/work/mono/mono/api-impl/fake/testdata/records.yaml does not have a tag, ignoring...
Image registry.test/contexts-testing/apko in file /home/runner/work/mono/mono/api-impl/fake/testdata/records.yaml does not have a tag, ignoring...
Processing pkg:oci/static in file /home/runner/work/mono/mono/api-impl/fake/testdata/records.yaml
2022/08/13 01:30:34 HEAD request failed, falling back on GET: could not parse reference: pkg:oci/static
Error: parsing reference "pkg:oci/static": could not parse reference: pkg:oci/static
Error: Process completed with exit code 1.
```

https://github.com/chainguard-dev/mono/runs/7815958440?check_suite_focus=true

Signed-off-by: Kenny Leung <kleung@chainguard.dev>