### PR TITLE
skip local registry for digestabot

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -16,6 +16,7 @@ runs:
     run: |
       while IFS= read -r -d '' file; do
         if [[ "$file" == *testdata* ]]; then
+          echo "Skipping testdata ${file}"
           continue
         fi
         images=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f1 | rev | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///" | tr '\n' ',' || true)
@@ -27,6 +28,10 @@ runs:
             for i in "${!images2[@]}"; do
               if [[ ${images2[i]} != *":"* ]]; then
                 echo "Image ${images2[i]} in file $file does not have a tag, ignoring..."
+                continue
+              fi
+              if [[ ${images2[i]} == *\.local:* ]]; then
+                echo "Skipping local registry image ${images2[i]}"
                 continue
               fi
               echo "Processing ${images2[i]} in file $file"


### PR DESCRIPTION
Skipping local registry that digestabot cant process

```
Processing registry.local:5000/policy-controller/demo in file /home/runner/work/mono/mono/.github/workflows/agentless-kind.yaml
2022/08/15 16:02:22 HEAD request failed, falling back on GET: Get "https://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving; Get "http://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving
Error: Get "https://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving; Get "http://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving
Error: Process completed with exit code 1.
```

Signed-off-by: Kenny Leung <kleung@chainguard.dev>