### PR TITLE
SPDX Tools Setup and SBOM validation action

### DIFF
--- a/setup-spdx/README.md
+++ b/setup-spdx/README.md
@@ -1,0 +1,89 @@
+# SPDX Tools Install and SBOM Verification
+
+This action installs the SPDX Java tools into the workflow
+environment and optionally verifies an SBOM to ensure its
+syntax conforms to the SPDX spec.
+
+## Steps
+
+It has two steps, both are optional:
+
+### Install SPDX Tools
+
+By default, the action will download and uncompress the java SPDX
+tools in the current directory. You can skip this step if running
+several validation steps.
+
+### Validate SBOM
+
+If an SBOM path is specified in the inputs, the action will run
+the `Verify` subcommand to check the syntax of the SBOM.
+
+## Usage 
+
+Here is a minimal example validating an SBOM stored in `sbom.spdx`:
+
+```yaml
+name: Validate SBOMs
+
+on:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  check-spdx:
+    name: Check SPDX SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chainguard-dev/actions/setup-spdx@main
+        with:
+          sbom-path: sbom.spdx
+```
+
+Here is a full example, it was initially written for the
+[Kubernetes `bom` tool](https://github.com/kubernetes-sigs/bom)
+verification step. It runs the action 3 times one to set up 
+the tools and one to verify each SBOM format (tag-value, json):
+
+```yaml
+name: Validate SBOMs
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+
+jobs:
+  check-spdx:
+    name: Check SPDX SBOMs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          check-latest: true
+      - uses: actions/checkout@v3.0.2
+      - run: |
+          go run ./cmd/bom/main.go generate -i registry.k8s.io/pause > example-image-pause.spdx
+          go run ./cmd/bom/main.go generate --format=json -i registry.k8s.io/pause > example-image-pause.spdx.json
+      - uses: chainguard-dev/actions/setup-spdx@spdx
+        with:
+          spdx-tools-version: 1.1.0
+      - uses: chainguard-dev/actions/setup-spdx@main
+        with:
+          download: false
+          spdx-tools-version: 1.1.0
+          sbom-path: example-image-pause.spdx
+      - uses: chainguard-dev/actions/setup-spdx@main
+        with:
+          download: false
+          spdx-tools-version: 1.1.0
+          sbom-path: example-image-pause.spdx.json
+      - uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: Example SBOMs
+          path: |
+            example-image-pause.spdx
+            example-image-pause.spdx.json
+```

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -45,16 +45,16 @@ on:
   push:
   workflow_dispatch:
 
-jobs:
-  runs-on: ubuntu-latest
-  sbom:
-    name: SPDX Verification Tools
-    steps:
-      - name: Install SPDX Tools
-        run: |
-          wget https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip
-          unzip tools-java-${{ inputs.spdx-tools-version }}.zip
-      - name: Validate SBOM
-        if: ${{ inputs.sbom-path != '' }}
-        run: |
-          java -jar ./tools-java-${{ inputs.spdx-tools-version }}-jar-with-dependencies.jar Verify ${{ inputs.sbom-path }} ${{ inputs.sbom-format }}
+runs:
+  using: composite
+  steps:
+  - name: Install SPDX Tools
+    shell: bash
+    run: |
+      wget https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip
+      unzip tools-java-${{ inputs.spdx-tools-version }}.zip
+  - name: Validate SBOM
+    if: ${{ inputs.sbom-path != '' }}
+    shell: bash
+    run: |
+      java -jar ./tools-java-${{ inputs.spdx-tools-version }}-jar-with-dependencies.jar Verify ${{ inputs.sbom-path }} ${{ inputs.sbom-format }}

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -11,10 +11,30 @@ inputs:
     description: |
       Path to the SBOM to be validated. The SBOM file name must have its extension
       matching its encoding type
-    default: 
+    required: false
 
-env:
-  SPDX_TOOLS_VERSION: 1.1.0
+  spdx-tools-version:
+    description: |
+      Version of the SPDX tools. 
+    default:  1.1.0
+    options:
+    - 1.1.0
+    - 1.0.4
+
+  sbom-format:
+    description: |
+      Encoding format of the SPDX document. The default is blank meaning that
+      the SPDX Verify subcommand will try to infer it from the file extension.
+    default:
+    options:
+    - 
+    - JSON
+    - TAG
+    - YAML
+    - XML
+    - XLS
+    - XLSX    
+    - RDFXML
 
 on:
   pull_request:
@@ -28,9 +48,9 @@ jobs:
     steps:
       - name: Install SPDX Tools
         run: |
-          wget https://github.com/spdx/tools-java/releases/download/v${SPDX_TOOLS_VERSION}/tools-java-${SPDX_TOOLS_VERSION}.zip
-          unzip tools-java-${SPDX_TOOLS_VERSION}.zip
+          wget https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip
+          unzip tools-java-${{ inputs.spdx-tools-version }}.zip
       - name: Validate SBOM
         if: ${{ inputs.sbom-path != '' }}
         run: |
-          java -jar ./tools-java-${SPDX_TOOLS_VERSION}-jar-with-dependencies.jar Verify ${{ inputs.sbom-path }}
+          java -jar ./tools-java-${{ inputs.spdx-tools-version }}-jar-with-dependencies.jar Verify ${{ inputs.sbom-path }} ${{ inputs.sbom-format }}

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup SPDX Tools'
+description: |
+  This actions sets up the SPDX tools jar in the environment 
+  and optionally verifies an SBOM specified in the input
+  
+inputs:
+  sbom-path:
+    description: |
+      Path to the SBOM to be validated. The SBOM file name must have its extension
+      matching its encoding type
+    default: 
+
+env:
+  SPDX_TOOLS_VERSION: 1.1.0
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+
+jobs:
+  runs-on: ubuntu-latest
+  sbom:
+    name: SPDX Verification Tools
+    steps:
+      - name: Install SPDX Tools
+        run: |
+          wget https://github.com/spdx/tools-java/releases/download/v${SPDX_TOOLS_VERSION}/tools-java-${SPDX_TOOLS_VERSION}.zip
+          unzip tools-java-${SPDX_TOOLS_VERSION}.zip
+      - name: Validate SBOM
+        if: ${{ inputs.sbom-path != '' }}
+        run: |
+          java -jar ./tools-java-${SPDX_TOOLS_VERSION}-jar-with-dependencies.jar Verify ${{ inputs.sbom-path }}

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -39,19 +39,13 @@ inputs:
     - XLSX    
     - RDFXML
 
-on:
-  pull_request:
-    branches: ['main']
-  push:
-  workflow_dispatch:
-
 runs:
   using: composite
   steps:
   - name: Install SPDX Tools
     shell: bash
     run: |
-      wget https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip
+      wget --progress=dot:giga https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip
       unzip tools-java-${{ inputs.spdx-tools-version }}.zip
   - name: Validate SBOM
     if: ${{ inputs.sbom-path != '' }}

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -24,6 +24,13 @@ inputs:
     - 1.1.0
     - 1.0.4
 
+  download:
+    description: |
+      When true, the action will try to download the SPDX tools jar. Useful
+      when running more than one validation.
+    default: true
+    type: boolean
+
   sbom-format:
     description: |
       Encoding format of the SPDX document. The default is blank meaning that
@@ -43,6 +50,7 @@ runs:
   using: composite
   steps:
   - name: Install SPDX Tools
+    if: ${{ inputs.download }}
     shell: bash
     run: |
       wget --progress=dot:giga https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -1,11 +1,14 @@
 # Copyright 2022 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+# Originally adapted from the ko SBOM verification action:
+# https://github.com/google/ko/blob/main/.github/workflows/sbom.yaml
+
 name: 'Setup SPDX Tools'
 description: |
-  This actions sets up the SPDX tools jar in the environment 
-  and optionally verifies an SBOM specified in the input
-  
+  This action sets up the SPDX tools jar in the workflow environment 
+  and optionally verifies an SBOM. 
+
 inputs:
   sbom-path:
     description: |
@@ -40,6 +43,7 @@ on:
   pull_request:
     branches: ['main']
   push:
+  workflow_dispatch:
 
 jobs:
   runs-on: ubuntu-latest

--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
   - name: Install SPDX Tools
-    if: ${{ inputs.download }}
+    if: ${{ inputs.download == 'true' }}
     shell: bash
     run: |
       wget --progress=dot:giga https://github.com/spdx/tools-java/releases/download/v${{ inputs.spdx-tools-version }}/tools-java-${{ inputs.spdx-tools-version }}.zip


### PR DESCRIPTION
This PR introduces a new reusable action based on the [`ko` SBOM verification action](https://github.com/google/ko/blob/main/.github/workflows/sbom.yaml) that installs the SPDX java tools jar and optionally checks an SBOM to ensure its syntax is valid.

This action will allow us to verify all SPDX SBOMs we produce in apko ([see here an initial use in `bom`](https://github.com/puerco/bom/blob/check-action/.github/workflows/verify-spdx.yaml)).