### PR TITLE
inky-build-pkg: change default signing key name to wolfi-signing.rsa

### DIFF
--- a/inky-build-pkg/action.yaml
+++ b/inky-build-pkg/action.yaml
@@ -21,7 +21,7 @@ inputs:
   signing-key-name:
     description: |
       The name of the signing key to use if signing is enabled.
-    default: melange.rsa
+    default: wolfi-signing.rsa
 
   repository-path:
     description: |


### PR DESCRIPTION
xref chainguard-dev/internal#667