### PR TITLE
add wolfi-build-pkg and deprecate inky-build-pkg

### DIFF
--- a/inky-build-pkg/README.md
+++ b/inky-build-pkg/README.md
@@ -1,0 +1,4 @@
+# inky-build-pkg
+
+This action will be deprecated in favor of `wolfi-build-pkg` action.
+

--- a/wolfi-build-pkg/action.yaml
+++ b/wolfi-build-pkg/action.yaml
@@ -1,0 +1,57 @@
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Build Wolfi package with melange'
+description: |
+  This action builds a single package using Melange, given a config file.
+  It deals with setting up the Melange build tool, repository, and signing
+  key.  It composes the melange-build-pkg option with defaults appropriate
+  for Inky.
+
+inputs:
+  package-name:
+    description: |
+      The package name to build.
+
+  archs:
+    description: |
+      The architectures to use.
+    default: x86_64
+
+  signing-key-name:
+    description: |
+      The name of the signing key to use if signing is enabled.
+    default: wolfi-signing.rsa
+
+  repository-path:
+    description: |
+      The path of the repository being constructed by Melange.
+    default: ${{ github.workspace }}/packages
+
+  empty-workspace:
+    description: |
+      Whether to begin with an empty workspace.
+    default: true
+
+  source-dir:
+    description: |
+      The directory to use for the --source-dir option if
+      empty-workspace is false.
+    default: ${{ github.workspace }}
+
+runs:
+  using: 'composite'
+
+  steps:
+    - uses: chainguard-dev/actions/melange-build-pkg@main
+      with:
+        config: ${{ inputs.package-name }}.yaml
+        archs: ${{ inputs.archs }}
+        sign-with-key: true
+        update-index: true
+        repository-append: ${{ github.workspace }}/packages
+        keyring-append: /etc/apk/keys/${{ inputs.signing-key-name }}.pub
+        workspace-dir: ${{ github.workspace }}/build/${{ inputs.package-name }}
+        empty-workspace: ${{ inputs.empty-workspace }}
+        signing-key-path: ${{ github.workspace }}/${{ inputs.signing-key-name }}
+        source-dir: ${{ inputs.source-dir }}


### PR DESCRIPTION
- add wolfi-build-pkg and deprecate inky-build-pkg

this will be a 2 step change, first we duplicate the action, then replace where we use and in the end we remove the old action