### PR TITLE
Always attempt to accept an invite code when specified.

### DIFF
--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,13 +47,20 @@ runs:
         AUDIENCE="${{ inputs.audience }}"
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')
 
-        if chainctl auth login --identity-token "${IDTOKEN}"; then
-          echo Logged in!
-        elif [[ -z "${CHAINGUARD_INVITE_CODE}" ]]; then
-          echo No invite code is present!  Failing since registration will not do any good.
-          echo Configure a secret named CHAINGUARD_INVITE_CODE to have this workload register itself.
-          exit 1
+        if [[ -z "${CHAINGUARD_INVITE_CODE}" ]]; then
+          if chainctl auth login --identity-token "${IDTOKEN}"; then
+            echo Logged in!
+          else
+            echo No invite code is present!  Failing since registration will not do any good.
+            echo Configure a secret named CHAINGUARD_INVITE_CODE to have this workload register itself.
+            exit 1
+          fi
         else
           # This will start failing once the invite code expires, which is why we have the login guard.
-          chainctl auth login --register --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}"
+          if chainctl auth login --create-group=false --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}"; then
+            echo Logged in!
+          else
+            echo Failed to log in with invite code
+            exit 1
+          fi
         fi


### PR DESCRIPTION
We hit a problem where trying to expand the capabilities of our actions runner didn't work because we weren't even trying to accept the invite code, and proceeded with inadequate capabilities.

This makes it so that we always try to do an idempotent invite code acceptance.