### PR TITLE
change metallb addresspool to use CRD vs. configmap.

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -24,7 +24,9 @@ jobs:
         - v1.22.x
         - v1.23.x
         - v1.24.x
-        - v1.25.x
+        # Do not test with this yet, 1.7.1 of knative breaks everything.
+        # and versions before it do not work with this.
+        # - v1.25.x
 
     steps:
     - name: Checkout the current action
@@ -34,3 +36,9 @@ jobs:
       uses: ./setup-kind
       with:
         k8s-version: ${{ matrix.k8s-version }}
+
+    - name: Test spinning up Knative also
+      id: knative
+      uses: ./setup-knative
+      with:
+        version: 1.6.0

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -182,21 +182,43 @@ runs:
         kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.5/config/manifests/metallb-native.yaml
         kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 
+        # Wait for metallb to be ready (or webhook will reject CRDs)
+        for x in $(kubectl get deploy --namespace metallb-system -oname); do
+          kubectl rollout status --timeout 5m --namespace metallb-system "$x"
+        done
+
         network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
-        cat <<EOF | kubectl apply -f -
-        apiVersion: v1
-        kind: ConfigMap
+        cat <<EOF >> ./metallb-crds.yaml
+        apiVersion: metallb.io/v1beta1
+        kind: IPAddressPool
         metadata:
-          namespace: metallb-system
           name: config
-        data:
-          config: |
-            address-pools:
-            - name: default
-              protocol: layer2
-              addresses:
-              - $network.255.1-$network.255.250
+          namespace: metallb-system
+        spec:
+          addresses:
+          - $network.255.1-$network.255.250
+        ---
+        apiVersion: metallb.io/v1beta1
+        kind: L2Advertisement
+        metadata:
+          name: empty
+          namespace: metallb-system
         EOF
+
+        for i in {1..10}
+        do
+          if kubectl apply -f ./metallb-crds.yaml ; then
+            echo successfully applied metallb crds
+            break
+          fi
+          if [ $i == 10 ]; then
+            echo failed to apply metallb crds. exiting
+            exit 1
+          fi
+
+          echo failed to apply metallb crds. Attempt numer $i, retrying
+          sleep 2
+        done
 
     - name: Setup Container Registry
       shell: bash


### PR DESCRIPTION
Previous of version was soooo old that so many things had changed, including how one defines the addresspools. So instead of using configmap, switch to using CRD.

Also add a test that spins up Knative to make sure cluster is functional.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>