### PR TITLE
add 'latest' keyword that will install mismatching versions of latest. Test with k8s v1.25.x

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -24,9 +24,7 @@ jobs:
         - v1.22.x
         - v1.23.x
         - v1.24.x
-        # Do not test with this yet, 1.7.1 of knative breaks everything.
-        # and versions before it do not work with this.
-        # - v1.25.x
+        - v1.25.x
 
     steps:
     - name: Checkout the current action
@@ -41,4 +39,4 @@ jobs:
       id: knative
       uses: ./setup-knative
       with:
-        version: 1.6.0
+        version: latest

--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -9,7 +9,9 @@ description: |
 inputs:
   version:
     description: |
-      The version of Knative to install, e.g. 1.5.0
+      The version of Knative to install, e.g. 1.5.0. Sometimes (like v1.7.x) of
+      Knative, the components are out of sync, so to work around that you can
+      specify "latest" and it will fetch the latest ones for all the components.
     required: true
     default: 1.5.0
 
@@ -67,8 +69,17 @@ runs:
         function resource_blaster() {
           local REPO="${1}"
           local FILE="${2}"
+          local REAL_KNATIVE_VERSION=${{ inputs.version }}
 
-          curl -L -s "https://github.com/knative/${REPO}/releases/download/knative-v${{ inputs.version }}/${FILE}" \
+          # If latest specified, fetch that instead. Note that this can vary
+          # between versions, so have to fetch for each component.
+          if [ ${{ inputs.version }} == "latest" ]; then
+            REAL_KNATIVE_VERSION=$(curl -L -s https://api.github.com/repos/knative/${REPO}/releases/latest | jq -r '.tag_name')
+          else
+            REAL_KNATIVE_VERSION="knative-v${{ inputs.version }}"
+          fi
+
+          curl -L -s "https://github.com/knative/${REPO}/releases/download/${REAL_KNATIVE_VERSION}/${FILE}" \
             | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
             `# Filter out empty objects that come out as {} b/c kubectl barfs` \
             | grep -v '^{}$'


### PR DESCRIPTION
Knative version v1.7.x is little wonky and some components were released with v1.7.1 and some with v1.7.0 and some don't have v1.7.1 or they have a release that doesn't work at v.1.7.0, so we can not use a single version to install. To unblock the testing with v1.25 of k8s, introduce a 'latest' keyword that will fetch the latest release for each component.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>