### PR TITLE
inky-build-pkg: use bash shell when creating optional patches directory

### DIFF
--- a/inky-build-pkg/action.yaml
+++ b/inky-build-pkg/action.yaml
@@ -32,7 +32,8 @@ runs:
   using: 'composite'
 
   steps:
-    - run: |
+    - shell: bash
+      run: |
         mkdir -p ${{ github.workspace }}/${{ inputs.package-name }}
     - uses: chainguard-dev/actions/melange-build-pkg@main
       with:


### PR DESCRIPTION
Why github actions doesn't just default to `bash`, the world will probably never know...