### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -19,7 +19,7 @@ jobs:
       - id: get_yamls
         run: |
           yamls=$(find . -name "*.yaml")
-          echo "::set-output name=files::${yamls}"
+          echo "files="${yamls}"" >> $GITHUB_OUTPUT
       - uses: reviewdog/action-actionlint@v1
         with:
           actionlint_flags: ${{ steps.get_yamls.outputs.files }}


### PR DESCRIPTION

#### Summary
- Use GITHUB_OUTPUT instead of deprecated set-output

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/