### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -84,4 +84,4 @@ runs:
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
         --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs
       echo EXIT CODE: $?
-      echo ::set-output name=digest::$(cat "${{ inputs.image_refs }}")
+      echo "digest=$(cat "${{ inputs.image_refs }}")" >> $GITHUB_OUTPUT

--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -49,7 +49,7 @@ runs:
     shell: bash
     run: |
       if [[ $(git diff --stat) != '' ]]; then
-        echo ::set-output name=create_pr::true
+        echo "create_pr=true" >> $GITHUB_OUTPUT
       fi
 
   # Configure signed commits

--- a/release-notes/action.yml
+++ b/release-notes/action.yml
@@ -107,7 +107,7 @@ runs:
         shell: bash
         run: |
           if [[ $(git diff --stat) != '' ]]; then
-            echo ::set-output name=create_pr::true
+            echo "create_pr=true" >> $GITHUB_OUTPUT
           fi
 
       # Configure signed commits

--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -205,7 +205,7 @@ runs:
 
         export IP=$(kubectl get svc -n istio-system istio-ingressgateway -ojsonpath={.status.loadBalancer.ingress[0].ip})
         echo LB IP: ${IP}
-        echo ::set-output name=load-balancer-ip::${IP}
+        echo "load-balancer-ip=${IP}" >> $GITHUB_OUTPUT
 
         # Required for minio
         kubectl patch cm config-domain -n knative-serving \

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -251,5 +251,5 @@ runs:
 
     - name: Set start time output
       id: start-time
-      run:  echo ::set-output name=kind-start-time::$(echo $(($(date +%s%N)/1000000)))
+      run: echo "kind-start-time=$(echo $(($(date +%s%N)/1000000)))" >> $GITHUB_OUTPUT
       shell: bash

--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -261,4 +261,4 @@ runs:
             ;;
         esac
         echo LB IP: ${IP}
-        echo ::set-output name=load-balancer-ip::${IP}
+        echo "load-balancer-ip=${IP}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### Summary
- Use GITHUB_OUTPUT instead of deprecated set-output

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/