### PR TITLE
Allow setup-melange to work when a melange/ directory already exists

### DIFF
--- a/setup-melange/action.yaml
+++ b/setup-melange/action.yaml
@@ -50,10 +50,11 @@ runs:
     - name: 'Install melange'
       shell: bash
       run: |
-        git clone https://github.com/chainguard-dev/melange
-        pushd melange
+        TMP_CLONE_DIR="$(mktemp -d)"
+        git clone https://github.com/chainguard-dev/melange "${TMP_CLONE_DIR}"
+        pushd "${TMP_CLONE_DIR}"
         make melange
         sudo env "PATH=$PATH" make install
         melange version
         popd
-        rm -rf ./melange
+        rm -rf "${TMP_CLONE_DIR}"


### PR DESCRIPTION
If using in a repo containing a `melange/` dir, bad stuff happens