### PR TITLE
Partially revert #173

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -149,11 +149,9 @@ runs:
 
         # This is needed in order to support projected volumes with service account tokens.
         # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        #
-        # We don't specify the API version since Kind is permissive when patching
-        # https://kubernetes.slack.com/archives/CEKK1KTN2/p1648855849643189?thread_ts=1648855553.841399&cid=CEKK1KTN2
         kubeadmConfigPatches:
           - |
+            apiVersion: kubeadm.k8s.io/v1beta2
             kind: ClusterConfiguration
             metadata:
               name: config


### PR DESCRIPTION
With this change we were seeing `sigstore/scaffolding` failing to start Fulcio with:
```
error loading --config-path=/etc/fulcio-config/config.json: provider https://kubernetes.default.svc.cluster.local/: oidc: issuer did not match the issuer returned by provider, expected "https://kubernetes.default.svc.cluster.local/" got "https://kubernetes.default.svc/"
```

This is concerning because the patch block is specifically requesting the issuer without `.cluster.local`.  Reverting this until we can sort out the reason for the behavior change.

cc @dprotaso @vaikas 