### PR TITLE
Fix: boilerplate for go 1.19

### DIFF
--- a/boilerplate/action.yaml
+++ b/boilerplate/action.yaml
@@ -49,13 +49,11 @@ runs:
   - name: Install Tools
     shell: bash
     run: |
-      TEMP_PATH="$(mktemp -d)"
+      cd "$(mktemp -d)"
 
       echo '::group:: Installing boilerplate-check ... https://github.com/mattmoor/boilerplate-check'
-      go get github.com/mattmoor/boilerplate-check/cmd/boilerplate-check
+      go install github.com/mattmoor/boilerplate-check/cmd/boilerplate-check@latest
       echo '::endgroup::'
-
-      echo "${TEMP_PATH}" >> $GITHUB_PATH
 
   - name: check boilerplate
     shell: bash


### PR DESCRIPTION
Updates boilerplate check to work with go 1.19.

Tested against the UI repo: https://github.com/chainguard-dev/console-ui/actions/runs/3660259108/jobs/6187205572