### PR TITLE
[gofmt/goimport] Don't limit find depth to 3.

### DIFF
--- a/gofmt/action.yaml
+++ b/gofmt/action.yaml
@@ -19,7 +19,7 @@ runs:
     shell: bash
     run: |
       # We limit the depth to 3 mostly to avoid go.mod files that get pulled into `third_party` like some hashicorp repos.
-      for dir in $(find . -name go.mod -maxdepth 3 -exec dirname {} \; ); do
+      for dir in $(find . -type d \( -path "*/third_party" -o -path "*/.terraform" \) -prune -o -name go.mod -exec dirname {} \;| sort ); do
         echo "::group:: $dir"
         pushd $dir
         gofmt ${{ inputs.args }} -w \

--- a/goimports/action.yaml
+++ b/goimports/action.yaml
@@ -27,7 +27,7 @@ runs:
     shell: bash
     run: |
       # We limit the depth to 3 mostly to avoid go.mod files that get pulled into `third_party` like some hashicorp repos.
-      for dir in $(find . -name go.mod -maxdepth 3 -exec dirname {} \; ); do
+      for dir in $(find . -type d \( -path "*/third_party" -o -path "*/.terraform" \) -prune -o -name go.mod -exec dirname {} \;| sort ); do
         echo "::group:: $dir"
         pushd $dir
         goimports -local="${{ inputs.local }}" -w \


### PR DESCRIPTION
This tweaks the find command to not have a hard depth limit of 3, and instead uses a -prune to limit the directories it will traverse down.