### PR TITLE
setup-chainctl: provide defaults for env and audience

### DIFF
--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -32,7 +32,5 @@ permissions:
 steps:
 - uses: chainguard-dev/actions/setup-chainctl@main
   with:
-    environment: example.com
-    audience: some-other-audience
     invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
 ```

--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -9,14 +9,14 @@ and authenticates with it using identity tokens.
 - uses: chainguard-dev/actions/setup-chainctl@main
   with:
     # environment determines the environment from which to download the chainctl
-    # binary from, it is required and has no default (for now).
-    # Required.
-    environment: cookie-monster
+    # binary from.
+    # Optional (default is enforce.dev)
+    environment: enforce.dev
     # audience is the identity token audience to use when creating an identity
     # token to authenticate with Chainguard, it is required and has no default
     # (for now).
-    # Required.
-    audience: oscar-the-grouch
+    # Optional (default is https://issuer.enforce.dev)
+    audience: https://issuer.enforce.dev
     # invite-code is an invitation code that may be used to have this workload
     # register itself with the Chainguard API the first time it executes.
     # Optional.
@@ -32,7 +32,7 @@ permissions:
 steps:
 - uses: chainguard-dev/actions/setup-chainctl@main
   with:
-    environment: big-bird
-    audience: elmo
+    environment: example.com
+    audience: some-other-audience
     invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
 ```

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -17,10 +17,9 @@ inputs:
   audience:
     description: |
       Specifies the identity token audience to use when creating an
-      identity token to authenticate with Chainguard, it is rquired
-      and has no default (for now).
-    required: true
-    default: https://issuer.enforce.dev
+      identity token to authenticate with Chainguard.
+      Defaults to https://issuer.${environment}
+    required: false
 
   invite-code:
     description: |
@@ -46,6 +45,10 @@ runs:
         CHAINGUARD_INVITE_CODE: ${{ inputs.invite-code }}
       run: |
         AUDIENCE="${{ inputs.audience }}"
+        if [[ -z "${AUDIENCE}" ]]; then
+          AUDIENCE=https://issuer.${{ inputs.environment }}
+        fi
+
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')
 
         if [[ -z "${CHAINGUARD_INVITE_CODE}" ]]; then

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -12,6 +12,7 @@ inputs:
       Determines the environment from which to download the chainctl
       binary from, it is required and has no default (for now).
     required: true
+    default: enforce.dev
 
   audience:
     description: |
@@ -19,13 +20,13 @@ inputs:
       identity token to authenticate with Chainguard, it is rquired
       and has no default (for now).
     required: true
+    default: https://issuer.enforce.dev
 
   invite-code:
     description: |
       Optionally specifies an invite code that allows this workflow
       register itself when run for the first time.
     required: false
-
 
 runs:
   using: "composite"
@@ -35,7 +36,7 @@ runs:
       shell: bash
       run: |
         cd $(mktemp -d)
-        wget -O chainctl "https://storage.googleapis.com/us.artifacts.${{ inputs.environment }}.appspot.com/chainctl_$(uname -s)_$(uname -m)"
+        wget -O chainctl "https://dl.${{ inputs.environment }}/chainctl_$(uname -s)_$(uname -m)"
         chmod +x chainctl
         sudo mv chainctl /usr/local/bin
 


### PR DESCRIPTION
Also use `https://dl.enforce.dev` instead of GCS.