### PR TITLE
cleanup: bump hakn default to 1.8.5 from 1.8.0

### DIFF
--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -11,7 +11,7 @@ inputs:
     description: |
       The version of Hakn to install, e.g. 1.8.0
     required: false
-    default: 1.8.0
+    default: 1.8.5
 
   istio-version:
     description: |


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

cleanup: bump hakn default to 1.8.5 from 1.8.0