### PR TITLE
update setup-chainguard-terraform to match setup-chainctl changes

### DIFF
--- a/.github/workflows/test-setup.yaml
+++ b/.github/workflows/test-setup.yaml
@@ -1,0 +1,18 @@
+name: test-setup
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-setup:
+    name: test-setup
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the current action
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+    # Test that installers successfully install.
+    - uses: ./setup-chainctl
+    - uses: ./setup-chainguard-terraform

--- a/.github/workflows/test-setup.yaml
+++ b/.github/workflows/test-setup.yaml
@@ -9,6 +9,10 @@ jobs:
     name: test-setup
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
     - name: Checkout the current action
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/test-setup.yaml
+++ b/.github/workflows/test-setup.yaml
@@ -1,7 +1,12 @@
 name: test-setup
 
 on:
-  pull_request:
+  # The test requires idtoken permissions, which are not available on
+  # pull_request. This means the workflow config will be taken from HEAD,
+  # so we checkout the PR merge commit explicitly below.
+  pull_request_target:
+    branches: [ main ]
+  push:
     branches: [ main ]
 
 jobs:
@@ -16,6 +21,8 @@ jobs:
     steps:
     - name: Checkout the current action
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     # Test that installers successfully install.
     - uses: ./setup-chainctl

--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -14,8 +14,8 @@ and authenticates with it using identity tokens.
     environment: enforce.dev
     # audience is the identity token audience to use when creating an identity
     # token to authenticate with Chainguard.
-    # Optional (default is https://issuer.enforce.dev)
-    audience: https://issuer.enforce.dev
+    # Optional (default is issuer.enforce.dev)
+    audience: issuer.enforce.dev
     # invite-code is an invitation code that may be used to have this workload
     # register itself with the Chainguard API the first time it executes.
     # Optional.

--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -13,8 +13,7 @@ and authenticates with it using identity tokens.
     # Optional (default is enforce.dev)
     environment: enforce.dev
     # audience is the identity token audience to use when creating an identity
-    # token to authenticate with Chainguard, it is required and has no default
-    # (for now).
+    # token to authenticate with Chainguard.
     # Optional (default is https://issuer.enforce.dev)
     audience: https://issuer.enforce.dev
     # invite-code is an invitation code that may be used to have this workload

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -18,7 +18,7 @@ inputs:
     description: |
       Specifies the identity token audience to use when creating an
       identity token to authenticate with Chainguard.
-      Defaults to https://issuer.${environment}
+      Defaults to issuer.${environment}
     required: false
 
   invite-code:
@@ -46,7 +46,7 @@ runs:
       run: |
         AUDIENCE="${{ inputs.audience }}"
         if [[ -z "${AUDIENCE}" ]]; then
-          AUDIENCE=https://issuer.${{ inputs.environment }}
+          AUDIENCE=issuer.${{ inputs.environment }}
         fi
 
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -10,7 +10,7 @@ inputs:
   environment:
     description: |
       Determines the environment from which to download the chainctl
-      binary from, it is required and has no default (for now).
+      binary from.
     required: true
     default: enforce.dev
 

--- a/setup-chainguard-terraform/README.md
+++ b/setup-chainguard-terraform/README.md
@@ -11,15 +11,14 @@ particular Chainguard environment.  There are two main things this does:
 ```yaml
 - uses: chainguard-dev/actions/setup-chainguard-terraform@main
   with:
-    # environment determines the environment from which to download the chainctl
-    # binary from, it is required and has no default (for now).
-    # Required.
-    environment: cookie-monster
+    # environment determines the environment from which to download the binary
+    # from.
+    # Optional (default is enforce.dev)
+    environment: enforce.dev
     # audience is the identity token audience to use when creating an identity
-    # token to authenticate with Chainguard, it is required and has no default
-    # (for now).
-    # Required.
-    audience: oscar-the-grouch
+    # token to authenticate with Chainguard.
+    # Optional (default is https://issuer.enforce.dev)
+    audience: https://issuer.enforce.dev
     # invite-code is an invitation code that may be used to have this workload
     # register itself with the Chainguard API the first time it executes.
     # Optional.
@@ -33,9 +32,7 @@ permissions:
   id-token: write
 
 steps:
-- uses: chainguard-dev/actions/setup-chainguard@main
+- uses: chainguard-dev/actions/setup-chainguard-terraform@main
   with:
-    environment: big-bird
-    audience: elmo
     invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
 ```

--- a/setup-chainguard-terraform/README.md
+++ b/setup-chainguard-terraform/README.md
@@ -17,8 +17,8 @@ particular Chainguard environment.  There are two main things this does:
     environment: enforce.dev
     # audience is the identity token audience to use when creating an identity
     # token to authenticate with Chainguard.
-    # Optional (default is https://issuer.enforce.dev)
-    audience: https://issuer.enforce.dev
+    # Optional (default is issuer.enforce.dev)
+    audience: issuer.enforce.dev
     # invite-code is an invitation code that may be used to have this workload
     # register itself with the Chainguard API the first time it executes.
     # Optional.

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -9,15 +9,16 @@ inputs:
   environment:
     description: |
       Determines the environment from which to download the chainctl
-      binary from, it is required and has no default (for now).
+      binary from.
     required: true
+    default: enforce.dev
 
   audience:
     description: |
       Specifies the identity token audience to use when creating an
-      identity token to authenticate with Chainguard, it is rquired
-      and has no default (for now).
-    required: true
+      identity token to authenticate with Chainguard.
+      Defaults to https://issuer.${environment}
+    required: false
 
   invite-code:
     description: |
@@ -31,6 +32,8 @@ runs:
   steps:
     - uses: chainguard-dev/actions/setup-chainctl@main
       with:
+        environment: ${{ inputs.environment }}
+        audience: ${{ inputs.audience }}
         invite-code: ${{ inputs.invite-code }}
 
     - shell: bash
@@ -38,7 +41,7 @@ runs:
         cat > ~/.terraformrc <<EOF
         provider_installation {
           network_mirror {
-            url = "https://storage.googleapis.com/us.artifacts.${{ inputs.environment }}.appspot.com/terraform-provider/"
+            url = "https://dl.${{ inputs.environment }}/terraform-provider/"
             include = [
               "registry.terraform.io/chainguard/chainguard",
             ]

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -30,10 +30,18 @@ runs:
   using: "composite"
 
   steps:
+    - id: default-audience
+      run: |
+        AUDIENCE="${{ inputs.audience }}"
+        if [[ -z "${AUDIENCE}" ]]; then
+          AUDIENCE=https://issuer.${{ inputs.environment }}
+        fi
+        echo "audience=${AUDIENCE}" >> $GITHUB_OUTPUT
+
     - uses: chainguard-dev/actions/setup-chainctl@main
       with:
         environment: ${{ inputs.environment }}
-        audience: ${{ inputs.audience }}
+        audience: ${{ steps.default-audience.outputs.audience }}
         invite-code: ${{ inputs.invite-code }}
 
     - shell: bash

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -34,7 +34,7 @@ runs:
       run: |
         AUDIENCE="${{ inputs.audience }}"
         if [[ -z "${AUDIENCE}" ]]; then
-          AUDIENCE=https://issuer.${{ inputs.environment }}
+          AUDIENCE=issuer.${{ inputs.environment }}
         fi
         echo "audience=${AUDIENCE}" >> $GITHUB_OUTPUT
 

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: |
       Specifies the identity token audience to use when creating an
       identity token to authenticate with Chainguard.
-      Defaults to https://issuer.${environment}
+      Defaults to issuer.${environment}
     required: false
 
   invite-code:


### PR DESCRIPTION
Also add some basic tests that setup-chainctl and setup-chainguard-terraform can successfully install without params.