### PR TITLE
setup-spdx: Bump spdx/tools-java to 1.1.3

### DIFF
--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -19,8 +19,9 @@ inputs:
   spdx-tools-version:
     description: |
       Version of the SPDX tools. 
-    default:  1.1.0
+    default:  1.1.3
     options:
+    - 1.1.3
     - 1.1.0
     - 1.0.4
 


### PR DESCRIPTION
Update the jar file to the last version of the SPDX java tools in the SPDX action

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>