### PR TITLE
Feature: Deprecate the invite-code path, add identity support

### DIFF
--- a/setup-chainguard-terraform/README.md
+++ b/setup-chainguard-terraform/README.md
@@ -11,18 +11,14 @@ particular Chainguard environment.  There are two main things this does:
 ```yaml
 - uses: chainguard-dev/actions/setup-chainguard-terraform@main
   with:
-    # environment determines the environment from which to download the binary
-    # from.
+    # environment determines the environment from which to download the chainctl
+    # binary from.
     # Optional (default is enforce.dev)
     environment: enforce.dev
-    # audience is the identity token audience to use when creating an identity
-    # token to authenticate with Chainguard.
-    # Optional (default is issuer.enforce.dev)
-    audience: issuer.enforce.dev
-    # invite-code is an invitation code that may be used to have this workload
-    # register itself with the Chainguard API the first time it executes.
-    # Optional.
-    invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
+
+    # identity holds the ID for the identity this workload should assume when
+    # speaking to Chainguard APIs.
+    identity: "..."
 ```
 
 ## Scenarios
@@ -34,5 +30,5 @@ permissions:
 steps:
 - uses: chainguard-dev/actions/setup-chainguard-terraform@main
   with:
-    invite-code: ${{ secrets.CHAINGUARD_INVITE_CODE }}
+    identity: "deadbeef/badf00d"
 ```

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -13,17 +13,27 @@ inputs:
     required: true
     default: enforce.dev
 
+  identity:
+    description: |
+      The id of the identity that this workflow should assume for
+      performing actions with chainctl.
+    required: false
+
   audience:
     description: |
       Specifies the identity token audience to use when creating an
       identity token to authenticate with Chainguard.
       Defaults to issuer.${environment}
+
+      This field is DEPRECATED, use identity instead.
     required: false
 
   invite-code:
     description: |
       Optionally specifies an invite code that allows this workflow
       register itself when run for the first time.
+
+      Use of invite codes is DEPRECATED, use identity instead.
     required: false
 
 runs:
@@ -44,6 +54,7 @@ runs:
         environment: ${{ inputs.environment }}
         audience: ${{ steps.default-audience.outputs.audience }}
         invite-code: ${{ inputs.invite-code }}
+        identity: ${{ inputs.identity }}
 
     - shell: bash
       run: |


### PR DESCRIPTION
:gift: This plumbs the new identity stuff through the `setup-chainguard-terraform` actions.

/kind feature