### PR TITLE
Add k8s 1.27.x support for setup-kind/action.yaml

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -25,6 +25,7 @@ jobs:
         - v1.24.x
         - v1.25.x
         - v1.26.x
+        - v1.27.x
 
         # See https://github.com/chainguard-dev/actions/pull/175
         # We're testing whether setting a custom cluster domain works

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -15,9 +15,9 @@ inputs:
 
   kind-version:
     description: |
-      The exact version of KinD to use in the form: 0.17.0
+      The exact version of KinD to use in the form: 0.18.0
     required: true
-    default: 0.17.0
+    default: 0.18.0
 
   kind-worker-count:
     description: |
@@ -107,8 +107,13 @@ runs:
           v1.25.x)
             echo "KIND_IMAGE=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1" >> $GITHUB_ENV
             ;;
+
           v1.26.x)
             echo "KIND_IMAGE=kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352" >> $GITHUB_ENV
+            ;;
+
+          v1.27.x)
+            echo "KIND_IMAGE=kindest/node:v1.27.1@sha256:9915f5629ef4d29f35b478e819249e89cfaffcbfeebda4324e5c01d53d937b09" >> $GITHUB_ENV
             ;;
 
           *) echo "Unsupported version: ${{ inputs.k8s-version }}"; exit 1 ;;

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -89,27 +89,27 @@ runs:
         case ${{ inputs.k8s-version }} in
 
           v1.21.x)
-            echo "KIND_IMAGE=kindest/node:v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.21.14@sha256:27ef72ea623ee879a25fe6f9982690a3e370c68286f4356bf643467c552a3888" >> $GITHUB_ENV
             ;;
 
           v1.22.x)
-            echo "KIND_IMAGE=kindest/node:v1.22.15@sha256:7d9708c4b0873f0fe2e171e2b1b7f45ae89482617778c1c875f1053d4cef2e41" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.22.17@sha256:c8a828709a53c25cbdc0790c8afe12f25538617c7be879083248981945c38693" >> $GITHUB_ENV
             ;;
 
           v1.23.x)
-            echo "KIND_IMAGE=kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.23.17@sha256:e5fd1d9cd7a9a50939f9c005684df5a6d145e8d695e78463637b79464292e66c" >> $GITHUB_ENV
             ;;
 
           v1.24.x)
-            echo "KIND_IMAGE=kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.24.12@sha256:1e12918b8bc3d4253bc08f640a231bb0d3b2c5a9b28aa3f2ca1aee93e1e8db16" >> $GITHUB_ENV
             ;;
 
           v1.25.x)
-            echo "KIND_IMAGE=kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.25.8@sha256:00d3f5314cc35327706776e95b2f8e504198ce59ac545d0200a89e69fce10b7f" >> $GITHUB_ENV
             ;;
 
           v1.26.x)
-            echo "KIND_IMAGE=kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.26.3@61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f" >> $GITHUB_ENV
             ;;
 
           v1.27.x)

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -109,7 +109,7 @@ runs:
             ;;
 
           v1.26.x)
-            echo "KIND_IMAGE=kindest/node:v1.26.3@61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f" >> $GITHUB_ENV
+            echo "KIND_IMAGE=kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f" >> $GITHUB_ENV
             ;;
 
           v1.27.x)


### PR DESCRIPTION
The KinD latest release has the 1.27.x support https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0

So this patch changes:
- bumps KinD version to v0.18.0.
- adds k8s 1.27.x support.

