### PR TITLE
setup-registry: use crane registry serve

### DIFF
--- a/.github/workflows/test-setup-registry.yaml
+++ b/.github/workflows/test-setup-registry.yaml
@@ -1,0 +1,21 @@
+name: test-setup-registry
+
+on: [pull_request]
+
+jobs:
+  test_action:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    permissions: {}
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: imjasonh/setup-crane@v0.3
+    - uses: ./setup-registry
+      with:
+        port: 8081
+    - run: |
+        curl -v https://localhost:8081/v2/
+        crane copy cgr.dev/chainguard/static:latest-glibc localhost:8081/static:test

--- a/.github/workflows/test-setup-registry.yaml
+++ b/.github/workflows/test-setup-registry.yaml
@@ -17,5 +17,5 @@ jobs:
       with:
         port: 8081
     - run: |
-        curl -v https://localhost:8081/v2/
+        curl -v http://localhost:8081/v2/
         crane copy cgr.dev/chainguard/static:latest-glibc localhost:8081/static:test

--- a/.github/workflows/test-setup-registry.yaml
+++ b/.github/workflows/test-setup-registry.yaml
@@ -4,11 +4,7 @@ on: [pull_request]
 
 jobs:
   test_action:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/setup-registry/action.yaml
+++ b/setup-registry/action.yaml
@@ -3,7 +3,7 @@
 
 name: 'Setup registry'
 description: |
-  This action sets up a simple in-memory OCI registry.
+  This action sets up a simple in-memory OCI registry for basic testing.
 
 inputs:
   port:
@@ -15,8 +15,9 @@ runs:
   using: "composite"
 
   steps:
-    - name: Install and run registry
+    - name: Install crane
+      uses: imjasonh/setup-crane@v0.3
+    - name: Run registry
       shell: bash
       run: |
-        go install github.com/google/go-containerregistry/cmd/registry@main
-        registry --port=${{ inputs.port }} &
+        PORT=${{inputs.port}} crane registry serve &


### PR DESCRIPTION
Using `setup-crane` means the latest release of the registry will be used, and the user doesn't have to have Go available to `go install` from source. This will be harder to mess up, and quite a bit faster as a bonus.

If we want to retain the old from-head behavior, we can add a parameter for `version` with the same semantics as `setup-crane`, with `default` meaning the latest release, and `tip` meaning `go install @main`, and other released versions available. I don't think anybody depends on this today though.

`crane registry serve` also has the ability to choose a random available port if one is not specified. This could be useful, but we'd want a way for `crane registry serve` and `setup-registry` to output the chosen port so subsequent steps can interact with the registry. For now, `port` is still required.