### PR TITLE
[WIP] add test for setup-chainctl

### DIFF
--- a/.github/workflows/test-setup-chainctl.yaml
+++ b/.github/workflows/test-setup-chainctl.yaml
@@ -1,0 +1,26 @@
+name: setup-chainctl
+
+on:
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the current action
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - name: setup-chainctl
+      uses: ./setup-chainctl
+
+    # Ensure chainctl was installed.
+    - run: chainctl version
+
+    # TODO: Set up an identity that can be assumed by this workflow, to test assumed identity login.


### PR DESCRIPTION
Seemed like a good idea to have presubmit tests for this 😄 

For the TODO, I can just create an identity in my own root group, but then I might accidentally delete it and break this test. Unbreaking it would be easy though.

Or, if you think it's worth it, I can setup this identity in our IaC so we ensure it's not owned by any specific person.

I was only planning to have the test do something like `chainctl auth status` and maybe pull a public image, just to prove it all works.