### PR TITLE
eof-newline: Ignore testdata directories.

### DIFF
--- a/eof-newline/action.yaml
+++ b/eof-newline/action.yaml
@@ -42,7 +42,8 @@ runs:
       git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
       grep -Ev '^(vendor/|third_party/|LICENSES/|.git)' |
       grep -v '\.ai$' |
-      grep -v '\.svg$')
+      grep -v '\.svg$' |
+      grep -v '/testdata/')
 
       for x in $LINT_FILES; do
         # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file


### PR DESCRIPTION
Sometimes testdata needs to have no newlines - e.g. if we're comparing data against a signature, adding a new line would invalidate existing signatures.