### PR TITLE
fix digesta bot

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -24,7 +24,7 @@ runs:
             echo "Skipping testdata ${file}"
             continue
           fi
-          images=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f1 | rev | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///" | tr '\n' ',' || true)
+          images=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f1 | rev | cut -d = -f1 | cut -d ' ' -f1 | cut -d '"' -f1 | rev | sed -e "s/^docker:\/\///" | tr '\n' ',' || true)
           digests=$(grep -i -E '[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*@sha256:[a-z0-9]+' "$file" | cut -d @ -f2 | cut -d ' ' -f1 | cut -d '"' -f1 | tr '\n' ',' || true)
           IFS=',' read -r -a images2 <<< "$images"
           IFS=',' read -r -a digests2 <<< "$digests"


### PR DESCRIPTION
use case:

```
      - op: replace
        path: /spec/template/spec/containers/0/args/3
        value: --acme-http01-solver-image=cgr.dev/chainguard/cert-manager-acmesolver:1.11.1@sha256:059c0b906e1f0f031e8a4a55d43e193d6b1e75e99f8eb9ae406ecdea7c99ec42
```



need to remove anything before `=`


Fixes: https://github.com/chainguard-dev/mono/issues/10123