### PR TITLE
eof-newline: Dump reviewdog input to stderr.

### DIFF
--- a/eof-newline/action.yaml
+++ b/eof-newline/action.yaml
@@ -52,7 +52,7 @@ runs:
           # Characters beyond the final <newline> character will not be included in the line count.
           echo $x:$((1 + $(wc -l $x | tr -s ' ' | cut -d' ' -f 1))): Missing newline
         fi
-      done |
+      done | tee /dev/stderr |
       reviewdog -efm="%f:%l: %m" \
             -name="EOF Newline" \
             -reporter="github-pr-check" \


### PR DESCRIPTION
The test is failing ambiguously, so dump out the reviewdog input for more details.

See https://github.com/chainguard-dev/mono/actions/runs/4983299872/jobs/8920138260?pr=10102 for example failure.