### PR TITLE
trailing-space: ignore testdata

### DIFF
--- a/trailing-space/action.yaml
+++ b/trailing-space/action.yaml
@@ -37,8 +37,8 @@ runs:
       git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
       git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
       git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
-      grep -Ev '^(vendor/|third_party/|LICENSES/|.git)' |
-      xargs grep -nE " +$" |
+      grep -Ev '^(vendor/|third_party/|LICENSES/|.git|/testdata/)' |
+      xargs grep -nE " +$" | tee /dev/stderr |
       reviewdog -efm="%f:%l:%m" \
             -name="trailing whitespace" \
             -reporter="github-pr-check" \


### PR DESCRIPTION
I'm pretty sure the input to reviewdog is also busted, but idk what the format is. Added additional logging to output what is being fed to reviewdog to stderr.