### PR TITLE
Silence spammy wget logs

### DIFF
--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: |
         cd $(mktemp -d)
-        wget -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
+        wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
         sudo mv chainctl /usr/local/bin
 


### PR DESCRIPTION
Before this change:

```
--2023-06-01 14:16:08--  https://dl.enforce.dev/chainctl/latest/chainctl_linux_x86_64
Resolving dl.enforce.dev (dl.enforce.dev)... 34.[117](https://github.com/chainguard-images/images/actions/runs/5145433910/jobs/9263121546#step:5:129).0.114
Connecting to dl.enforce.dev (dl.enforce.dev)|34.117.0.114|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 57966592 (55M) [application/octet-stream]
Saving to: ‘chainctl’

     0K .......... .......... .......... .......... ..........  0% 24.8M 2s
    50K .......... .......... .......... .......... ..........  0% 47.5M 2s
   100K .......... .......... .......... .......... ..........  0% 50.4M 1s
   150K .......... .......... .......... .......... ..........  0% 90.3M 1s
   200K .......... .......... .......... .......... ..........  0% 98.2M 1s
   250K .......... .......... .......... .......... ..........  0% 92.7M 1s
   300K .......... .......... .......... .......... ..........  0% 96.6M 1s
   350K .......... .......... .......... .......... ..........  0% 93.8M 1s
   400K .......... .......... .......... .......... ..........  0% 96.4M 1s
   450K .......... .......... .......... .......... ..........  0%  101M 1s
   500K .......... .......... .......... .......... ..........  0% 97.6M 1s
...
```

and lots of tedious scrolling.