### PR TITLE
Setup chainctl remove the need for sudo

### DIFF
--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -46,9 +46,8 @@ runs:
       run: |
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
-
-        # Ensure install directory exists and is on the PATH
         CHAINCTL_INSTALL_PATH="${HOME}/.local/bin"
+        # Ensure install directory is on the PATH for future steps
         echo "${CHAINCTL_INSTALL_PATH}" >> "${GITHUB_PATH}"
         install -D --mode 0555 ./chainctl --target-directory "${CHAINCTL_INSTALL_PATH}"
 

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,6 +47,7 @@ runs:
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
+        mkdir -p "${HOME}/.local/bin/"
         mv chainctl "${HOME}/.local/bin/"
 
     - name: Authenticate with Chainguard (assumed identity)

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -49,7 +49,7 @@ runs:
         chmod +x chainctl
 
         # Create the local bin and install chainctl
-        export CHAINCTL_INSTALL_PATH="${HOME}/.local/bin/"
+        export CHAINCTL_INSTALL_PATH="${HOME}/.local/bin"
         mkdir -p "${CHAINCTL_INSTALL_PATH}"
         echo "${CHAINCTL_INSTALL_PATH}" >> "${GITHUB_PATH}"
 

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,8 +47,13 @@ runs:
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
-        mkdir -p "${HOME}/.local/bin/"
-        mv chainctl "${HOME}/.local/bin/"
+
+        # Create the local bin and install chainctl
+        export CHAINCTL_INSTALL_PATH="${HOME}/.local/bin/"
+        mkdir -p "${CHAINCTL_INSTALL_PATH}"
+        echo "${CHAINCTL_INSTALL_PATH}" >> "${GITHUB_PATH}"
+
+        mv chainctl "${CHAINCTL_INSTALL_PATH}"
 
     - name: Authenticate with Chainguard (assumed identity)
       shell: bash

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -46,14 +46,11 @@ runs:
       run: |
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
-        chmod +x chainctl
 
-        # Create the local bin and install chainctl
-        export CHAINCTL_INSTALL_PATH="${HOME}/.local/bin"
-        mkdir -p "${CHAINCTL_INSTALL_PATH}"
+        # Ensure install directory exists and is on the PATH
+        CHAINCTL_INSTALL_PATH="${HOME}/.local/bin"
         echo "${CHAINCTL_INSTALL_PATH}" >> "${GITHUB_PATH}"
-
-        mv chainctl "${CHAINCTL_INSTALL_PATH}"
+        install -D --mode 0555 ./chainctl --target-directory "${CHAINCTL_INSTALL_PATH}"
 
     - name: Authenticate with Chainguard (assumed identity)
       shell: bash

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,7 +47,7 @@ runs:
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
-        mv chainctl "${HOME}/.local/bin
+        mv chainctl "${HOME}/.local/bin"
 
     - name: Authenticate with Chainguard (assumed identity)
       shell: bash

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,7 +47,7 @@ runs:
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
-        sudo mv chainctl /usr/local/bin
+        mv chainctl "${HOME}/.local/bin
 
     - name: Authenticate with Chainguard (assumed identity)
       shell: bash

--- a/setup-chainctl/action.yaml
+++ b/setup-chainctl/action.yaml
@@ -47,7 +47,7 @@ runs:
         cd $(mktemp -d)
         wget --quiet -O chainctl "https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_linux_$(uname -m)"
         chmod +x chainctl
-        mv chainctl "${HOME}/.local/bin"
+        mv chainctl "${HOME}/.local/bin/"
 
     - name: Authenticate with Chainguard (assumed identity)
       shell: bash


### PR DESCRIPTION
Previously our action required sudo to move the chainctl binary to `/usr/local/bin`. Moving it to `~/.local/bin` does not require sudo. I suspect the original action breaks on self-hosted runners, setting some up now to test and confirm