### PR TITLE
digestabot: fix required permissions in README example

### DIFF
--- a/digesta-bot/README.md
+++ b/digesta-bot/README.md
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
enable OIDC needed by gitsign