### PR TITLE
remove v from the k8s-version to match the others and update docs

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         k8s-version:
         - v1.24.x
-        - v1.25.x
-        - v1.26.x
-        - v1.27.x
+        - 1.25.x
+        - 1.26.x
+        - 1.27.x
 
         # See https://github.com/chainguard-dev/actions/pull/175
         # We're testing whether setting a custom cluster domain works

--- a/setup-kind/README.md
+++ b/setup-kind/README.md
@@ -10,7 +10,7 @@ This action spins up a KinD cluster with a handful of useful knobs exposed.
     # K8s version is the minor version of Kubernetes to install (with v).
     # For example, v1.27.x.
     # Required.
-    k8s-version: v1.27.x
+    k8s-version: 1.27.x
     # KinD Version is the version of KinD to use to orchestrate things (without v).
     # For example, 0.12.0.
     # Required.
@@ -37,5 +37,5 @@ This action spins up a KinD cluster with a handful of useful knobs exposed.
 steps:
 - uses: chainguard-dev/actions/setup-kind@main
   with:
-    k8s-version: 1.23.x
+    k8s-version: 1.24.x
 ```

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -9,13 +9,13 @@ description: |
 inputs:
   k8s-version:
     description: |
-      The version of Kubernetes to use in the form: 1.23.x
+      The version of Kubernetes to use in the form: 1.24.x
     required: true
-    default: 1.23.x
+    default: 1.24.x
 
   kind-version:
     description: |
-      The exact version of KinD to use in the form: 0.19.0
+      The exact version of KinD to use in the form: 0.20.0
     required: true
     default: 0.20.0
 
@@ -92,33 +92,34 @@ runs:
     - name: Determine KinD Image
       shell: bash
       run: |
-        case ${{ inputs.k8s-version }} in
+        K8SVERSION=${{ inputs.k8s-version }}
+        case ${K8SVERSION//v} in
 
-          v1.21.x)
+          1.21.x)
             echo "KIND_IMAGE=kindest/node:v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093" >> $GITHUB_ENV
             ;;
 
-          v1.22.x)
+          1.22.x)
             echo "KIND_IMAGE=kindest/node:v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2" >> $GITHUB_ENV
             ;;
 
-          v1.23.x)
+          1.23.x)
             echo "KIND_IMAGE=kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb" >> $GITHUB_ENV
             ;;
 
-          v1.24.x)
+          1.24.x)
             echo "KIND_IMAGE=kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab" >> $GITHUB_ENV
             ;;
 
-          v1.25.x)
+          1.25.x)
             echo "KIND_IMAGE=kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8" >> $GITHUB_ENV
             ;;
 
-          v1.26.x)
+          1.26.x)
             echo "KIND_IMAGE=kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb" >> $GITHUB_ENV
             ;;
 
-          v1.27.x)
+          1.27.x)
             echo "KIND_IMAGE=kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72" >> $GITHUB_ENV
             ;;
 


### PR DESCRIPTION
follow up of https://github.com/chainguard-dev/actions/pull/255