### PR TITLE
Fix gitsign binary name on OSX/ARM64

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -80,7 +80,7 @@ runs:
                 ;;
 
               ARM64)
-                gitsign_filename=gitsign_${gitsign_version}_darwin_amd64
+                gitsign_filename=gitsign_${gitsign_version}_darwin_arm64
                 gitsign_sha=${gitsign_darwin_arm64_sha}
                 ;;
 


### PR DESCRIPTION
The binary used for ARM64 was `amd64`. 🚨 
