### PR TITLE
add apiVersion field for ClusterConfiguration

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -166,6 +166,7 @@ runs:
         # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
         kubeadmConfigPatches:
           - |
+            apiVersion: kubeadm.k8s.io/v1beta2
             kind: ClusterConfiguration
             metadata:
               name: config


### PR DESCRIPTION
@wlynch @vaikas as best as I can tell, this is the root cause of the flakiness we're observed of late in sigstore/scaffolding. the `apiVersion` string is set in https://github.com/sigstore/scaffolding/blob/2221b2ecb9a1d64896dd042bebacd3668fd456fb/hack/setup-kind.sh#L166, and given the note in https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-ClusterConfiguration where it states "kubeadm v1.22.x and newer no longer support v1beta1 and older APIs", I suspect that without this string that the patch fails to successfully translate. 

https://github.com/sigstore/scaffolding/pull/715 if you'd like to see me wrestle this to the ground via GHA ping-pong.