### PR TITLE
boilerplate: disable caching for setup-go

### DIFF
--- a/boilerplate/action.yaml
+++ b/boilerplate/action.yaml
@@ -41,6 +41,7 @@ runs:
     with:
       go-version: '1.20'
       check-latest: true
+      cache: false
 
   - uses: reviewdog/action-setup@8e48baae926e97848f0863ae248f3b08e089c81f # v1.0.5
     with:


### PR DESCRIPTION
This should disable the `Warning: Restore cache failed: Dependencies file is not found` warning message in action logs.