### PR TITLE
setup-kind: Add a new parameter to define the service account issuer

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -80,3 +80,9 @@ jobs:
       uses: ./setup-knative
       with:
         version: latest
+
+    - name: Collect diagnostics
+      if: ${{ failure() }}
+      uses: chainguard-dev/actions/kind-diag@main
+      with:
+        artifact-name: logs.${{ matrix.k8s-version }}

--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -74,9 +74,16 @@ jobs:
           fi
         fi
 
-    - name: Test spinning up Knative also
-      if: steps.changed-kind.outputs.any_changed == 'true'
+    - name: Test spinning up Knative also using v1.10.0
+      if: ${{ steps.changed-kind.outputs.any_changed == 'true' && matrix.k8s-version  == 'v1.24.x' }}
       id: knative
+      uses: ./setup-knative
+      with:
+        version: 1.10.0
+
+    - name: Test spinning up Knative also using latest
+      if: ${{ steps.changed-kind.outputs.any_changed == 'true' && matrix.k8s-version  != 'v1.24.x' }}
+      id: knative-latest
       uses: ./setup-knative
       with:
         version: latest

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -7,6 +7,12 @@ description: |
   configuration knobs.
 
 inputs:
+  service-account-issuer:
+    description: |
+      The service account issuer defines the identifier of the service account token issuer: https://kubernetes.default.svc 
+    required: false
+    default: "https://kubernetes.default.svc"
+
   k8s-version:
     description: |
       The version of Kubernetes to use in the form: 1.24.x
@@ -171,7 +177,7 @@ runs:
               name: config
             apiServer:
               extraArgs:
-                "service-account-issuer": "https://kubernetes.default.svc"
+                "service-account-issuer": "${{ inputs.service-account-issuer }}"
                 "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
                 "service-account-jwks-uri": "https://kubernetes.default.svc/openid/v1/jwks"
                 "service-account-key-file": "/etc/kubernetes/pki/sa.pub"


### PR DESCRIPTION
We are facing many issues due to a change in the fulcio configuration for the kubernetes issuer, this creates a mismatch to what the kubernetes cluster sets and what the oidc issuer expects.

Therefore I believe we need this new parameter to adapt the want/got expectations.