### PR TITLE
dont fail the job if cannot get the digest for a specific image but instead log that error

### DIFF
--- a/digesta-bot/action.yml
+++ b/digesta-bot/action.yml
@@ -31,6 +31,9 @@ inputs:
   commit-message:
     description: 'The message to use when committing changes.'
     default: 'Update images digests'
+  create-pr:
+    description: 'Create a PR or just keep the changes locally.'
+    default: true
 
 outputs:
   pull_request_number:
@@ -44,6 +47,8 @@ runs:
 
     - shell: bash
       run: |
+        # disable the errexit github enable that by default
+        set +o errexit
         while IFS= read -r -d '' file; do
           if [[ "$file" == *testdata* ]]; then
             echo "Skipping testdata ${file}"
@@ -65,7 +70,19 @@ runs:
                   continue
                 fi
                 echo "Processing ${images2[i]} in file $file"
-                updated_digest=$(crane digest "${images2[i]}")
+
+                crane digest "${images2[i]}" > digest.log 2> logerror.txt
+                if [ $? -eq 0 ]; then
+                    updated_digest=$(cat digest.log)
+                else
+                    ERRMSG="Failed to retrive digest info for ${images2[i]}"
+                    echo "${ERRMSG}"
+                    echo "${ERRMSG}" >> "$GITHUB_STEP_SUMMARY"
+                    cat logerror.txt >> "$GITHUB_STEP_SUMMARY"
+                fi
+                rm -f logerror.txt
+                rm -f digest.log
+
                 if [ "$updated_digest" != "${digests2[i]}" ] && [ -n "$updated_digest" ]; then
                   echo "Digest ${digests2[i]} for image ${images2[i]} is different, new digest is $updated_digest, updating..."
                   sed -i -e "s/${digests2[i]}/$updated_digest/g" "$file"
@@ -78,7 +95,8 @@ runs:
       id: create_pr
       shell: bash
       run: |
-        if [[ $(git diff --stat) != '' ]]; then
+        echo "create_pr=false" >> $GITHUB_OUTPUT
+        if [[ $(git diff --stat) != '' ]] && [[ ${{ inputs.create-pr }} == 'true' ]]; then
           echo "create_pr=true" >> $GITHUB_OUTPUT
         fi
 


### PR DESCRIPTION
- don't fail the job if cannot get the digest for a specific image but instead log that error


also add an option to skip PR creation.

the errors will be reported in the in the job summary, ie see below

<img width="1435" alt="Screenshot 2023-08-30 at 19 57 00" src="https://github.com/chainguard-dev/actions/assets/4115580/f2c551e5-5406-4446-9f9f-302e055b9011">
