### PR TITLE
k8s-diag: add pod logs and cluster events

### DIFF
--- a/k8s-diag/action.yaml
+++ b/k8s-diag/action.yaml
@@ -71,6 +71,26 @@ runs:
           done
         done
 
+    - name: Collect pod diagnostics
+      shell: bash
+      run: |
+        for ns in $(kubectl get ns -oname | cut -d'/' -f 2); do
+          for pod in $(kubectl get pods -n $ns -o name); do
+            echo "::group:: $ns logs $pod"
+            kubectl logs -n${ns} $pod || true
+            echo '::endgroup::'
+          done
+        done
+
+    - name: Collect events diagnostics
+      shell: bash
+      run: |
+        for ns in $(kubectl get ns -oname | cut -d'/' -f 2); do
+          echo "::group:: $ns events"
+          kubectl get events --field-selector type!=Normal --sort-by=.metadata.creationTimestamp -o wide -n${ns} || true
+          echo '::endgroup::'
+        done
+
     - name: Collect kind specific logs
       if: ${{ inputs.cluster-type == 'kind' }}
       shell: bash


### PR DESCRIPTION
This PR introduces 2 new diagnostics steps for Kubernetes cluster:
* Pod Logs by Namespece
* Events by Namespece

I could add `events` to `inputs.cluster-resources` make it would resulting non-easy UX. By using `get events`, we can able to pass some _filters_ and _sorting_ options. It would provide easy debugging. 