### PR TITLE
fix: Bump our min K8s version to v1.26 add k8s 1.28

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -128,6 +128,9 @@ runs:
           1.27.x)
             echo "KIND_IMAGE=kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72" >> $GITHUB_ENV
             ;;
+          1.28.x)
+            echo "KIND_IMAGE=kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31" >> $GITHUB_ENV
+            ;;
 
           *) echo "Unsupported version: ${{ inputs.k8s-version }}"; exit 1 ;;
         esac


### PR DESCRIPTION
Spin up the Kubernetes version to 1.28.
#318 