### PR TITLE
add kindest image for version 1.28.x

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -129,6 +129,10 @@ runs:
             echo "KIND_IMAGE=kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72" >> $GITHUB_ENV
             ;;
 
+          1.28.x)
+            echo "KIND_IMAGE=kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31" >> $GITHUB_ENV
+            ;;
+
           *) echo "Unsupported version: ${{ inputs.k8s-version }}"; exit 1 ;;
         esac
 


### PR DESCRIPTION
# Changes
- Adding Kindest image reference for version 1.28.x
- Image SHA from: https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0