### PR TITLE
setup-kind: fix indented heredoc end-marker

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -159,9 +159,9 @@ runs:
         if [ ${{ inputs.kind-worker-count }} -ne 0 ]; then
           for node in {1..${{ inputs.kind-worker-count }}}; do
           cat >> kind.yaml <<EOF
-          - role: worker
-            image: "${KIND_IMAGE}"
-          EOF
+        - role: worker
+          image: "${KIND_IMAGE}"
+        EOF
           done
         fi
 


### PR DESCRIPTION
Currently broken, see https://github.com/chainguard-dev/actions/pull/335