### PR TITLE
chore: add support for 1.29.x in setup-kind

### DIFF
--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -133,6 +133,10 @@ runs:
             echo "KIND_IMAGE=kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31" >> $GITHUB_ENV
             ;;
 
+          1.29.x)
+            echo "KIND_IMAGE=kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570" >> $GITHUB_ENV
+            ;;
+
           *) echo "Unsupported version: ${{ inputs.k8s-version }}"; exit 1 ;;
         esac
 


### PR DESCRIPTION
We want to use kubernetes version 1.29.x in https://github.com/sigstore/scaffolding, but that action uses chainguard's setup-kind action which does not support kubernetes version v1.29.

This PR adds support for kubernetes version 1.29.

cc @wlynch @mattmoor @cpanato 