### PR TITLE
Add an action for federating for octo-sts tokens

### DIFF
--- a/octo-sts/README.md
+++ b/octo-sts/README.md
@@ -1,0 +1,43 @@
+# `octo-sts`
+
+This action federates the Github actions identity token for a Github App token
+according to the Trust Policy in the target organization or repository.
+
+## Usage
+
+```yaml
+permissions:
+  id-token: write # Needed to federate tokens.
+
+steps:
+- uses: chainguard-dev/actions/octo-sts@main
+  id: octo-sts
+  with:
+    # environment determines the environment from which to download the chainctl
+    # binary from.
+    # Optional (default is enforce.dev)
+    scope: your-org/your-repo
+
+    # identity holds the ID for the identity this workload should assume when
+    # speaking to Chainguard APIs.
+    identity: foo
+
+- env:
+    GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+  run: |
+    gh repo list
+```
+
+The above will load a "trust policy" from `.github/chainguard/foo.sts.yaml` in
+the repository `your-org/your-repo`.  Suppose this contains the following, then
+workflows in `my-org/my-repo` will receive a token with the specified
+permissions on `my-org/my-repo`.
+
+```yaml
+issuer: https://token.actions.githubusercontent.com
+subject: repo:my-org/my-repo:ref:refs/heads/main
+
+permissions:
+  contents: read
+  issues: write
+```

--- a/octo-sts/action.yaml
+++ b/octo-sts/action.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Octo STS'
+description: |
+  This action exchanges the workflow's identity token for a Github App token
+  from the Octo STS service, in accordance with the trust policy of the target
+  organization or repository.
+
+inputs:
+  scope:
+    description: |
+      The org/repo of the repository to which to request access.
+    required: true
+
+  identity:
+    description: |
+      The name of the trust policy to load from the target repository. The trust policy
+      is loaded from https://github.com/{scope} from the file
+      .github/chainguard/{identity}.sts.yaml
+    required: true
+
+outputs:
+  token:
+    description: |
+      The federated token to use for authentication.
+    value: ${{ steps.octo-sts.outputs.token }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - shell: bash
+      id: octo-sts
+      run: |
+        THIS_TOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=octo-sts.dev" | jq -r .value)
+        THAT_TOKEN=$(curl -H "Authorization: Bearer ${THIS_TOKEN}" "https://octo-sts.dev/sts/exchange?scope=${{ inputs.scope }}&identity=${{ inputs.identity }}" | jq -r .token)
+        if [[ "${THAT_TOKEN}" == "null" ]] ; then
+          echo "Failed to obtain token from Octo STS" >&2
+          echo ::error::$(curl -H "Authorization: Bearer ${THIS_TOKEN}" "https://octo-sts.dev/sts/exchange?scope=${{ inputs.scope }}&identity=${{ inputs.identity }}" | jq -r .message)
+          exit 1
+        fi
+        echo "::add-mask::${THAT_TOKEN}"
+        echo "token=${THAT_TOKEN}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
An example of it working with `gh` CLI:
<img width="524" alt="image" src="https://github.com/chainguard-dev/actions/assets/2442466/8821ce47-beda-4b6b-8d6d-9dd3710886aa">

An example failure:
<img width="876" alt="image" src="https://github.com/chainguard-dev/actions/assets/2442466/1acc50b2-73d3-4e15-9868-58c9ca8386ed">

Fixes: https://github.com/chainguard-dev/octo-sts/issues/5