### PR TITLE
upgrade arifact actions to v4

### DIFF
--- a/k8s-diag/action.yaml
+++ b/k8s-diag/action.yaml
@@ -114,7 +114,7 @@ runs:
         k3d version -ojson > $out/k3d/k3d-version.json
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: /tmp/${{ inputs.artifact-name }}

--- a/kind-diag/action.yaml
+++ b/kind-diag/action.yaml
@@ -130,7 +130,7 @@ runs:
         tar -zvcf /tmp/${{ inputs.artifact-name }}.tar.gz -C /tmp temp.tar
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}.tar.gz
         path: /tmp/${{ inputs.artifact-name }}.tar.gz

--- a/nodiff/action.yaml
+++ b/nodiff/action.yaml
@@ -71,7 +71,7 @@ runs:
         git diff HEAD > diff.patch
     - name: Upload patch
       if: failure()
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: diff
         path: diff.patch

--- a/release-notes/action.yml
+++ b/release-notes/action.yml
@@ -88,7 +88,7 @@ runs:
         cat CHANGELOG_NEW.md
 
     - name: Archive Release Notes
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: CHANGELOG_${{ inputs.end_rev }}.md
         path: CHANGELOG_NEW.md

--- a/setup-spdx/README.md
+++ b/setup-spdx/README.md
@@ -79,7 +79,7 @@ jobs:
           download: false
           spdx-tools-version: 1.1.0
           sbom-path: example-image-pause.spdx.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: Example SBOMs


### PR DESCRIPTION
v3 ones are deprecated, use obsolete node and will break in Autumn
2024. v4 ones are compatible and faster.

This should remove lots of warnings in all the actions.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
