### PR TITLE
add deprecation warning to `setup-chainguard-terraform`

### DIFF
--- a/setup-chainctl/README.md
+++ b/setup-chainctl/README.md
@@ -6,7 +6,7 @@ and authenticates with it using identity tokens.
 setup-chainctl has a new home, please use https://github.com/chainguard-dev/setup-chainctl
 
 ```yaml
-- uses: chainguard-dev/setup-chainctl@v0.1.0
+- uses: chainguard-dev/setup-chainctl@v0.1.1
 ```
 
 _note_: this readme will be removed around August/2024

--- a/setup-chainguard-terraform/README.md
+++ b/setup-chainguard-terraform/README.md
@@ -1,10 +1,9 @@
 # Setup `chainguard-terraform-provider`
 
-This action configures the use of the Chainguard terraform provider for a
-particular Chainguard environment.  There are two main things this does:
-1. Installs/Authenticates `chainctl` for the particular environment,
-2. Configure a `~/.terraformrc` that pulls the Chainguard provider from our GCS
-  bucket for this environment.
+> :warning: **This action is depecrated.** Please use https://github.com/chainguard-dev/setup-chainctl
+
+This action installs the latest `chainctl` binary for a particular environment
+and authenticates with it using identity tokens.
 
 ## Usage
 

--- a/setup-chainguard-terraform/action.yaml
+++ b/setup-chainguard-terraform/action.yaml
@@ -40,6 +40,15 @@ runs:
   using: "composite"
 
   steps:
+    - id: deprecation-message
+      shell: bash
+      run: |
+        echo "*****************************************************************"
+        echo "**            This action is deprecated                        **"
+        echo "** please use https://github.com/chainguard-dev/setup-chainctl **"
+        echo "*****************************************************************"
+        echo "::warning file=action.yml,line=1,col=0,endColumn=1::Action is deprecated, check the readme"
+        
     - id: default-audience
       shell: bash
       run: |


### PR DESCRIPTION
`setup-chainguard-terraform` simply calls out to `chainguard-dev/setup-chainctl`. Deprecate this action in favor of `setup-chainctl`.