### PR TITLE
Add tag.gpgsign true to gitsign Action

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -104,6 +104,7 @@ runs:
         git config --global commit.gpgsign true       # Sign all commits
         git config --global gpg.x509.program gitsign  # Use gitsign for signing
         git config --global gpg.format x509           # gitsign expects x509 args
+        git config --global tag.gpgsign true          # Sign all tags
 
         # Use workflow name as the username
         git config --global user.name "${{ github.workflow }}"


### PR DESCRIPTION
This is a small PR that adds `git config --global tag.gpgsign true` to the `setup-gitsign` Action.

The Gitsign Configuration section mentions this option but the Action does not currently handle it automatically:
https://github.com/sigstore/gitsign?tab=readme-ov-file#configuration