### PR TITLE
fix find for actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - id: get_yamls
         run: |
-          yamls=$(find . -name "*.yaml" -iname '.chainguard/source.yaml')
+          yamls=$(find . -name "*.y*ml")
           echo "files="${yamls}"" >> $GITHUB_OUTPUT
       - uses: reviewdog/action-actionlint@v1
         with:

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -22,8 +22,9 @@ jobs:
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - id: get_yamls
         run: |
-          yamls=$(find . -name "*.y*ml")
-          echo "files="${yamls}"" >> $GITHUB_OUTPUT
+          set -xv
+          yamls=$(find . -name "*.y*ml" -not -path "*/.chainguard/source.yaml" -exec echo {} +)
+          echo "files=${yamls}" >> "$GITHUB_OUTPUT"
       - uses: reviewdog/action-actionlint@v1
         with:
           actionlint_flags: ${{ steps.get_yamls.outputs.files }}


### PR DESCRIPTION
by default it ANDs the name flags, so it only matched one file previously

change it to match any *.yaml or *.yml file