### PR TITLE
Add git repo URL and commit SHA parameters

### DIFF
--- a/melange-build-pkg/action.yaml
+++ b/melange-build-pkg/action.yaml
@@ -90,6 +90,16 @@ inputs:
       Directory used for pipelines
     default: ''
 
+  git-commit:
+    description: |
+      Commit hash of the git repository containing the build config file
+    default: ''
+
+  git-repo-url:
+    description: |
+      URL of the git repository containing the build config file
+    default: ''
+
 runs:
   using: 'composite'
 
@@ -108,6 +118,8 @@ runs:
         [ -n '${{ inputs.namespace }}' ] && nsarg="--namespace ${{ inputs.namespace }}"
         [ -n '${{ inputs.cache-dir }}' ] && cachearg="--cache-dir=${{ inputs.cache-dir }}"
         [ -n '${{ inputs.pipeline-dir }}' ] && pipelinedirarg="--pipeline-dir=${{ inputs.pipeline-dir }}"
+        [ -n '${{ inputs.git-commit }}' ] && gitcommitarg="--git-commit ${{ inputs.git-commit }}"
+        [ -n '${{ inputs.git-repo-url }}' ] && gitrepoarg="--git-repo-url ${{ inputs.git-repo-url }}"
         ${{ inputs.empty-workspace }} && workspacearg="$workspacearg --empty-workspace"
         ${{ inputs.empty-workspace }} || workspacearg="$workspacearg --source-dir ${{ inputs.source-dir }}/${{ inputs.workdir }}"
         ${{ inputs.sign-with-key }} && signarg="--signing-key ${{ inputs.signing-key-path }}"
@@ -121,7 +133,7 @@ runs:
             repoarg="${repoarg} --repository-append ${{ inputs.repository-path }}"
             keyringarg="${keyringarg} --keyring-append ${{ inputs.signing-key-path }}.pub"
           fi
-          sudo melange build $config --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg $indexarg $nsarg $cachearg $pipelinedirarg
+          sudo melange build $config --arch ${{ inputs.archs }} --out-dir ${{ inputs.repository-path }} $signarg $repoarg $keyringarg $workspacearg $indexarg $nsarg $cachearg $pipelinedirarg $gitcommitarg $gitrepoarg
         done
     - name: 'Fix local repository permissions'
       shell: bash

--- a/melange-build/action.yaml
+++ b/melange-build/action.yaml
@@ -76,6 +76,16 @@ inputs:
       Directory used for pipelines
     default: ''
 
+  git-commit:
+    description: |
+      Commit hash of the git repository containing the build config file
+    default: ''
+
+  git-repo-url:
+    description: |
+      URL of the git repository containing the build config file
+    default: ''
+
 runs:
   using: 'composite'
 
@@ -104,3 +114,5 @@ runs:
         workdir: ${{ inputs.workdir }}
         cache-dir: ${{ inputs.cache-dir }}
         pipeline-dir: ${{ inputs.pipeline-dir }}
+        git-commit: ${{ inputs.git-commit }}
+        git-repo-url: ${{ inputs.git-repo-url }}


### PR DESCRIPTION
Allows providing the URL of the git repository and the commit SHA containing the build config file.

Needed due to this change: https://github.com/chainguard-dev/melange/commit/eab3401f8019e134af6fe070e4d4bcff57993d30