### PR TITLE
Update setup-gitsign to 0.11.0

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -38,13 +38,13 @@ runs:
           esac
         }
 
-        gitsign_version='0.10.2'
-        gitsign_linux_amd64_sha='f9dfe821d0456f11de444de4d90ccd64d7797b5992161f3318b9bf85871c8f78'
-        gitsign_linux_arm64_sha='f65cca3498038e76f089ec473f9bdce83bf7e2aa15bbdc147b5b222aa0287ceb'
-        gitsign_darwin_amd64_sha='5efdf5541d3698f32b60bdfc3f9dfca8d3bff5960b69b95081b72e88c23cc02f'
-        gitsign_darwin_arm64_sha='e8f31efc33c74484f56e2ee8cc889fe4eafd66da150ab53e2438b03c4be548a4'
-        gitsign_windows_amd64_sha='c14f4cd67becb7e6937a1a8c363c88468cabaae959401b80e5340ad6fde5cbcc'
-        gitsign_windows_arm64_sha='b86113bb9a14a4446bb0758cd35d9708907ff2037e816ec838f2caf75c3d342c'
+        gitsign_version='0.11.0'
+        gitsign_linux_amd64_sha='af5003e17ea616cd65990012a42750b673a648ef23570e79ef3e5c4fdf411856'
+        gitsign_linux_arm64_sha='99af60d77ebfd48efd87799174590a2411625f1f79a511ee4436b1d05198b032'
+        gitsign_darwin_amd64_sha='bbe5e34046f2fe1d13d040a74108f337ce3727423f6843e7a89bfcf618e3e4ba'
+        gitsign_darwin_arm64_sha='48f91bb6f74e9befe2adb491c9d85293009aeb003d05978897dec858cfaa6847'
+        gitsign_windows_amd64_sha='519e267a48dbe4db5544877b2f6aa986f54497848aea1acd4387f5f983f64135'
+        gitsign_windows_arm64_sha='c66efe4aea0a4051725e6c21fd3264ca9209e77b384c08c0f387a11e75f026b5'
         gitsign_executable_name=gitsign
 
         trap "popd >/dev/null" EXIT


### PR DESCRIPTION
It's been a while since `gitsign` `0.10.2` was released -- `0.11.0` released 11/04 so I wanted to make sure it made its way into the action.