### PR TITLE
pin reviewdog/action-actionlint to specific commit

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -25,6 +25,6 @@ jobs:
           set -xv
           yamls=$(find . -name "*.y*ml" -not -path "*/.chainguard/source.yaml" -not -path "*/action.yaml" -exec echo {} +)
           echo "files=${yamls}" >> "$GITHUB_OUTPUT"
-      - uses: reviewdog/action-actionlint@v1
+      - uses: reviewdog/action-actionlint@db58217885f9a6570da9c71be4e40ec33fe44a1f # v1.65.0
         with:
           actionlint_flags: ${{ steps.get_yamls.outputs.files }}


### PR DESCRIPTION
The action was pointing to the v1 tag, so pinned to the current commit and also added a comment for the specific version tag associated with it, so that dependabot can keep it up to date.

The v1.65.0 tag is confirmed to be the same commit as the v1 tag:

```
$ git ls-remote https://github.com/reviewdog/action-actionlint | grep db58217885f9a6570da9c71be4e40ec33fe44a1f
db58217885f9a6570da9c71be4e40ec33fe44a1f        refs/heads/releases/v1
db58217885f9a6570da9c71be4e40ec33fe44a1f        refs/tags/v1^{}
db58217885f9a6570da9c71be4e40ec33fe44a1f        refs/tags/v1.65^{}
db58217885f9a6570da9c71be4e40ec33fe44a1f        refs/tags/v1.65.0^{}
```

or see https://github.com/reviewdog/action-actionlint/tags directly

I have also verified that the same commit was used in the most recent github action lint run on this repository:
https://github.com/chainguard-dev/actions/actions/runs/13901437278/job/38893955837#step:1:27

> `Download action repository 'reviewdog/action-actionlint@v1' (SHA:db58217885f9a6570da9c71be4e40ec33fe44a1f)`


Ref: https://github.com/chainguard-dev/prodsec/issues/60