### PR TITLE
update deprecated flag

### DIFF
--- a/boilerplate/action.yaml
+++ b/boilerplate/action.yaml
@@ -76,6 +76,6 @@ runs:
             -name="${{ inputs.language }} headers" \
             -reporter="github-pr-check" \
             -filter-mode="diff_context" \
-            -fail-on-error="true" \
+            -fail-level="error" \
             -level="error"
       echo '::endgroup::'


### PR DESCRIPTION
```
  time=2025-03-20T08:17:55.486Z level=WARN msg="reviewdog: -fail-on-error is deprecated. Use -fail-level=any, or -fail-level=error for github-[pr-]check reporter instead. See also https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md"

```