### PR TITLE
Add tag signing configuration to setup-gitsign action

### DIFF
--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -102,6 +102,7 @@ runs:
 
         # Configure
         git config --global commit.gpgsign true       # Sign all commits
+        git config --global tag.gpgsign true          # Sign all tags
         git config --global gpg.x509.program gitsign  # Use gitsign for signing
         git config --global gpg.format x509           # gitsign expects x509 args
 


### PR DESCRIPTION
FYI: gitsign can now also verify a tag signed by gitsign. https://github.com/sigstore/gitsign/pull/659
