### PR TITLE
Update gitsign to 0.13.0

### DIFF
--- a/.github/workflows/test-gitsign.yaml
+++ b/.github/workflows/test-gitsign.yaml
@@ -3,7 +3,7 @@ name: test-gitsign
 on:
   pull_request:
     paths:
-      - './setup-gitsign/**'
+      - 'setup-gitsign/**'
       - '.github/workflows/test-gitsign.yaml'
 
 jobs:

--- a/.github/workflows/test-gitsign.yaml
+++ b/.github/workflows/test-gitsign.yaml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         os:
           - macos-latest
+          - macos-13
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
 
     runs-on: ${{ matrix.os }}

--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -38,13 +38,13 @@ runs:
           esac
         }
 
-        gitsign_version='0.11.0'
-        gitsign_linux_amd64_sha='af5003e17ea616cd65990012a42750b673a648ef23570e79ef3e5c4fdf411856'
-        gitsign_linux_arm64_sha='99af60d77ebfd48efd87799174590a2411625f1f79a511ee4436b1d05198b032'
-        gitsign_darwin_amd64_sha='bbe5e34046f2fe1d13d040a74108f337ce3727423f6843e7a89bfcf618e3e4ba'
-        gitsign_darwin_arm64_sha='48f91bb6f74e9befe2adb491c9d85293009aeb003d05978897dec858cfaa6847'
-        gitsign_windows_amd64_sha='519e267a48dbe4db5544877b2f6aa986f54497848aea1acd4387f5f983f64135'
-        gitsign_windows_arm64_sha='c66efe4aea0a4051725e6c21fd3264ca9209e77b384c08c0f387a11e75f026b5'
+        gitsign_version='0.13.0'
+        gitsign_linux_amd64_sha='011af11d57ad205b4ae4e3f41ecc8c64fbe0043c829190c0cb44fce6fce74bbb'
+        gitsign_linux_arm64_sha='f0ec4732696b88f133ab6ef9ac2fe8be843ab9540bd1cc51dc4143142a858372'
+        gitsign_darwin_amd64_sha='3ced8e5fd81ef1e2428c1ab2c635a1b5440174c6164bc97c76bab159127bafb7'
+        gitsign_darwin_arm64_sha='f9b4f9c7e8f5890399397861196b896ce3f83256b128ae4c3aca013d5841ba8c'
+        gitsign_windows_amd64_sha='da5f80ca35cd1faefb6d796571fe051e8365440ee28e50fd9b190f30942bca65'
+        gitsign_windows_arm64_sha='b578cb40238ba94fe67bbb3e12617ec0a79be6d34ea4b6217ecf9ec653b431aa'
         gitsign_executable_name=gitsign
 
         trap "popd >/dev/null" EXIT


### PR DESCRIPTION
This PR updates gitsign from `0.11.0` to `0.13.0`.

I also added coverage for linux-arm64 and darwin-amd64. GitHub doesn't offer windows-arm64 Runners yet, so that's the one gap we can't cover easily.