### PR TITLE
Add new ARM64 Windows Runner to Gitsign matrix

### DIFF
--- a/.github/workflows/test-gitsign.yaml
+++ b/.github/workflows/test-gitsign.yaml
@@ -16,6 +16,7 @@ jobs:
           - macos-13
           - ubuntu-latest
           - ubuntu-24.04-arm
+          - windows-11-arm
           - windows-latest
 
     runs-on: ${{ matrix.os }}

--- a/setup-gitsign/action.yml
+++ b/setup-gitsign/action.yml
@@ -80,7 +80,7 @@ runs:
 
           Windows-ARM64)
             gitsign_filename=gitsign_${gitsign_version}_windows_arm64.exe
-            gitsign_sha=${gitsign_darwin_arm64_sha}
+            gitsign_sha=${gitsign_windows_arm64_sha}
             gitsign_executable_name=gitsign.exe
             ;;
 


### PR DESCRIPTION
We can now test installation coverage across all three Mac/Linux/Windows architecture pairs: https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/