### PR TITLE
Add release job 

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,11 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/actions:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/actions/.github/workflows/release.yaml@refs/heads/main
+
+# the release workflow needs write permissions to create and push tags
+permissions:
+  contents: write

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -23,7 +23,7 @@ jobs:
       - id: get_yamls
         run: |
           set -xv
-          yamls=$(find . -name "*.y*ml" -not -path "*/.chainguard/source.yaml" -not -path "*/action.yaml" -exec echo {} +)
+          yamls=$(find . -name "*.y*ml" -not -path "*/.chainguard/source.yaml" -not -path "*/action.yaml" -not -path "*/.github/chainguard/release.sts.yaml" -not -path ".goreleaser.yml" -exec echo {} +)
           echo "files=${yamls}" >> "$GITHUB_OUTPUT"
       - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,10 +55,10 @@ jobs:
           git fetch --tags
           if [ -z "$(git tag --points-at HEAD)" ]; then
             echo "Nothing points at HEAD, bump a new tag"
-            echo "bump=yes" >> $GITHUB_OUTPUT
+            echo "bump=yes" >> "$GITHUB_OUTPUT"
           else
             echo "A tag already points to head, don't bump"
-            echo "bump=no" >> $GITHUB_OUTPUT
+            echo "bump=no" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
@@ -68,7 +68,7 @@ jobs:
           identity: release
 
       - name: Bump and push Git tag
-        uses: chainguard-dev/actions/git-tag@855d928df4d35ab87d1495993810ba7725a2f8bb # v1.0.0
+        uses: chainguard-dev/actions/git-tag@f309c81b34d59c103f5b86a2e55a2a647dc8b40a # v1.0.1
         if: steps.check.outputs.bump == 'yes'
         with:
           token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,91 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: release-actions
+
+on:
+  schedule:
+   - cron: '0 0 * * 1' # weekly on Monday at 00:00
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "dry-run mode: if true, no git tags will be pushed."
+        type: boolean
+        default: false
+      release_type:
+        description: "Type of Release"
+        required: true
+        default: build
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - prerelease
+          - build
+      forced_version:
+        description: "(Optional) SemVer2-compliant forced-version to tag explicitly, instead of auto-bumping.
+                      Must not already exist"
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # to read the repo and tags
+      id-token: write # to inject the OIDC token to octo-sts
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check if any changes since last tag
+        id: check
+        run: |
+          git fetch --tags
+          if [ -z "$(git tag --points-at HEAD)" ]; then
+            echo "Nothing points at HEAD, bump a new tag"
+            echo "bump=yes" >> $GITHUB_OUTPUT
+          else
+            echo "A tag already points to head, don't bump"
+            echo "bump=no" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: release
+
+      - name: Bump and push Git tag
+        uses: chainguard-dev/actions/git-tag@855d928df4d35ab87d1495993810ba7725a2f8bb # v1.0.0
+        if: steps.check.outputs.bump == 'yes'
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          git_tag_prefix: "v"
+          bump_level: ${{ inputs.release_type || 'patch' }}
+          dry_run: ${{ inputs.dry_run || 'false'}}
+          forced_version: ${{ inputs.forced_version || '' }}
+          author: "octo-sts[bot] <157150467+octo-sts[bot]@users.noreply.github.com>"
+          committer: "octo-sts[bot] <157150467+octo-sts[bot]@users.noreply.github.com>"
+
+      # to create a GH release and fill with the changelog
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        if: steps.check.outputs.bump == 'yes'
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,11 +2,14 @@ version: 2
 
 project_name: actions
 
+# used only to help with the GH release and changelog
+# no builds :)
+
 builds:
   - skip: true
 
 release:
-  draft: false # allow for manual edits
+  draft: false
 
 changelog:
   use: github-native

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,12 @@
+version: 2
+
+project_name: actions
+
+builds:
+  - skip: true
+
+release:
+  draft: false # allow for manual edits
+
+changelog:
+  use: github-native


### PR DESCRIPTION
The idea here is to run a release every week if we have changes in the repository; then it will tag and create a new GH release, and with that, we then can pin the chainguard-dev/actions to a tagged hash :)
