### PR TITLE
Only run release workflow from chainguard-dev/actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,8 @@ permissions: {}
 
 jobs:
   release:
+    if: ${{ github.repository == 'chainguard-dev/actions' }}
+
     name: release
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Any forks of this repository will have this workflow attempt to run. It will fail because it does not have credentials to run.

Error looks like this:

    Error: no installation found for "smoser"