### PR TITLE
Add setup-eksctl workflow.

### DIFF
--- a/.github/workflows/test-setup-eksctl.yaml
+++ b/.github/workflows/test-setup-eksctl.yaml
@@ -1,0 +1,66 @@
+name: test-setup-eksctl
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - './setup-eksctl/**'
+      - '.github/workflows/test-setup-eksctl.yaml'
+
+permissions: {}
+
+jobs:
+  test-github-action:
+    name: test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # install an old version, and check that we got the expected version
+      - uses: "./setup-eksctl"
+        with:
+          version: "v0.209.0"
+
+      - name: verify version
+        shell: bash
+        run: |
+          out=$(/usr/local/bin/eksctl info) || {
+            echo "FATAL: execution of /usr/local/bin/eksctl failed $?"
+            exit 1
+          }
+
+          expected=0.209.0
+          found=$(echo "$out" | awk '$0 ~ /^eksctl version:/ { printf("%s\n", $3); }')
+          [ "$found" = "$expected" ] || {
+            echo "FATAL: expected version '$expected'. found '$found'"
+            exit 1
+          }
+          echo "verified version $expected was installed"
+
+      - uses: "./setup-eksctl"
+
+      # install latest (no 'release' input needed) and check that
+      # we have a version other than the one above.
+      - name: verify latest
+        shell: bash
+        run: |
+          out=$(/usr/local/bin/eksctl info) || {
+            echo "FATAL: execution of /usr/local/bin/eksctl failed $?"
+            exit 1
+          }
+
+          ver=$(echo "$out" | awk '$0 ~ /^eksctl version:/ { printf("%s\n", $3); }')
+          [ "$ver" != "0.209.0" ]
+
+          echo "installed eksctl version = $ver"
+          eksctl info

--- a/setup-eksctl/README.md
+++ b/setup-eksctl/README.md
@@ -1,0 +1,15 @@
+# Setup eksctl
+
+This action installs eksctl into /usr/local/bin
+
+## Usage
+
+```yaml
+- uses: chainguard-dev/actions/setup-eksctl@xxxxxxxxxxxx # vX.Y.Z
+```
+
+```yaml
+- uses: chainguard-dev/actions/setup-eksctl@xxxxxxxxxxxx # vX.Y.Z
+  with:
+    version: v0.210.0
+```

--- a/setup-eksctl/action.yaml
+++ b/setup-eksctl/action.yaml
@@ -1,0 +1,67 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Setup eksctl'
+description: |
+  Install eksctl into /usr/local/bin
+
+inputs:
+  version:
+    description: 'Version of eksctl to install'
+    required: true
+    default: 'latest'
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: "Install eksctl"
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        [ -n "$VERSION" ] || { echo "FATAL: version input is empty"; exit 1; }
+
+        # install eksctl
+        m=$(uname -m)
+        case "$m" in
+          x86_64) arch=amd64;;
+          aarch64) arch=arm64;;
+          *) echo "FATAL: unknown output for 'uname -m' : '$m'";;
+        esac
+        uname_s=$(uname -s)
+        platform="${uname_s}_${arch}"
+        fname="eksctl_${platform}.tar.gz"
+
+        burl="https://github.com/eksctl-io/eksctl/releases"
+        if [ "$VERSION" = "latest" ]; then
+           url="$burl/$VERSION/download"
+        else
+           url="$burl/download/$VERSION"
+        fi
+
+        echo "download eksctl for ${uname_s}/$arch platform from $url/$fname"
+        curl -sL "$url/$fname" > "$fname" ||
+           { echo "FATAL: download failed $url"; exit 1; }
+
+        cksum_url="$url/eksctl_checksums.txt"
+        echo "verify download against ${cksum_url}"
+        curl -sL "${cksum_url}" > "checksums.txt" ||
+           { echo "FATAL: failed to download checksums from $cksum_url"; exit 1; }
+        grep "$platform" checksums.txt > checksums.platform || {
+          echo "FATAL: '$platform' not found in checksums.txt";
+          cat checksums.txt
+          exit 1
+        }
+        sha256sum --check < checksums.platform ||
+           { echo "FATAL: checksum verification of $fname failed"; exit 1; }
+
+        echo "extract to /usr/local/bin"
+        mkdir -p /usr/local/bin
+        tar -C /usr/local/bin -xvf "$fname"
+        rm "$fname"
+
+    - name: "Show eksctl info"
+      shell: bash
+      run: |
+        /usr/local/bin/eksctl info


### PR DESCRIPTION
This is copied from wolfi-vm [test-eks-node](https://github.com/chainguard-dev/wolfi-vm/blob/ef34a43e9a3418d184017ca3f230456e1bb65616/.github/workflows/test-eks-node.yaml) workflow with minor improvements.

Upon landing, we should move the wolfi-vm workflow to use this.