### PR TITLE
setup-melange - better determining of release version.

### DIFF
--- a/setup-melange/action.yaml
+++ b/setup-melange/action.yaml
@@ -69,7 +69,7 @@ runs:
           url="https://api.github.com/repos/chainguard-dev/melange/releases/latest"
           curl --fail -s -u "username:${{ github.token }}" "$url" > "$tmpf" ||
             { echo "error in github api call for latest melange release"; exit 1; }
-          tag=$(jq .tag_name < "$tmpf") ||
+          tag=$(jq -r .tag_name < "$tmpf") ||
             { echo "error parsing json from $url"; exit 1; }
 
           if [ -z "$tag" ]; then


### PR DESCRIPTION
The previous version of this code would output over 11,000 lines (and growing) to stderr in a user of this action.  This is much more direct.