### PR TITLE
setup-knative: Fix bug in version=="latest" case

### DIFF
--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -96,7 +96,8 @@ runs:
           elif [ "${REPO}" == "eventing" -a "${{ inputs.eventing-version }}" != "" ]; then
             REAL_KNATIVE_VERSION="knative-v${{ inputs.eventing-version }}"
           elif [ ${{ inputs.version }} == "latest" ]; then
-            REAL_KNATIVE_VERSION=$(git ls-remote --tags --refs https://github.com/knative/${REPO} | awk '{print $2}' | sed 's/refs\/tags\/.*v//g' | sort -V | tail -1)
+            VERSION=$(git ls-remote --tags --refs https://github.com/knative/${REPO} | awk '{print $2}' | sed 's/refs\/tags\/.*v//g' | sort -V | tail -1)
+            REAL_KNATIVE_VERSION="knative-v${VERSION}"
           # It will match only if the input is something like `1.2.x` if there is any trailing chars (`1.2.xa`) that will not match
           elif [[ ${{ inputs.version }} == *".x" ]]; then
             INPUT=$(echo ${{ inputs.version }} | sed 's/.x//g')


### PR DESCRIPTION
REAL_KNATIVE_VERSION must be prefixed with "knative-v", PR #656 broke that.

Fixes #657.

Again, not really tested as part of the action but seems right to me.