### PR TITLE
setup-registry: Use non-deprecated flag for disk storage

### DIFF
--- a/setup-registry/action.yaml
+++ b/setup-registry/action.yaml
@@ -41,4 +41,4 @@ runs:
       shell: bash
       env:
         PORT: ${{inputs.port}}
-      run: crane registry serve --blobs-to-disk=true &
+      run: crane registry serve --disk=$(mktemp -d) &


### PR DESCRIPTION
Without this, we get 'Flag --blobs-to-disk has been deprecated, and will stop working in a future release. use --disk=$(mktemp -d) instead.'