### PR TITLE
setup-registry: Set PORT env var from input through workflow

### DIFF
--- a/setup-registry/action.yaml
+++ b/setup-registry/action.yaml
@@ -32,11 +32,13 @@ runs:
     - name: Run registry
       if: ${{inputs.disk != 'true' }}
       shell: bash
-      run: |
-        PORT=${{inputs.port}} crane registry serve &
+      env:
+        PORT: ${{inputs.port}}
+      run: crane registry serve &
 
     - name: Run registry
       if: ${{inputs.disk == 'true' }}
       shell: bash
-      run: |
-        PORT=${{inputs.port}} crane registry serve --blobs-to-disk=true &
+      env:
+        PORT: ${{inputs.port}}
+      run: crane registry serve --blobs-to-disk=true &


### PR DESCRIPTION
Instead of interpolating Github inputs directly, pass them in as env vars to avoid code injection.