### PR TITLE
setup-registry: Always install an actually released version

### DIFF
--- a/setup-registry/action.yaml
+++ b/setup-registry/action.yaml
@@ -20,14 +20,7 @@ runs:
 
   steps:
     - name: Install crane
-      if: ${{inputs.disk != 'true' }}
       uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
-
-    - name: Install crane
-      if: ${{inputs.disk == 'true' }}
-      uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
-      with:
-        version: tip
 
     - name: Run registry
       if: ${{inputs.disk != 'true' }}


### PR DESCRIPTION
I suppose we used to install `tip` since the disk-serving was bleeding edge. It no longer is though, so we can just use actual releases.