### PR TITLE
otel-export: use RUNNER_NAME for the current job

### DIFF
--- a/otel-export/lib/collector.ts
+++ b/otel-export/lib/collector.ts
@@ -28,32 +28,20 @@ interface GitHubJob {
 }
 
 export function findCurrentJob(jobs: GitHubJob[], currentJobName: string): GitHubJob {
+  // RUNNER_NAME uniquely identifies the current job regardless of how GitHub
+  // formats the display name (reusable workflows, matrix expansions, etc.).
+  const runnerName = process.env.RUNNER_NAME;
+  if (runnerName) {
+    const byRunner = jobs.find((j) => j.runner_name === runnerName);
+    if (byRunner) return byRunner;
+  }
+
   const exactMatch = jobs.find((job) => job.name === currentJobName);
   if (exactMatch) return exactMatch;
 
-  // For matrix jobs, GITHUB_JOB is the base name without matrix values
-  const matrixJobs = jobs.filter((job) => job.name.startsWith(currentJobName + ' ('));
+  const matrixMatch = jobs.find((job) => job.name.startsWith(currentJobName + ' ('));
+  if (matrixMatch) return matrixMatch;
 
-  if (matrixJobs.length === 1) {
-    return matrixJobs[0];
-  } else if (matrixJobs.length > 1) {
-    const runnerName = process.env.RUNNER_NAME;
-    if (runnerName) {
-      const jobByRunner = matrixJobs.find((j) => j.runner_name === runnerName);
-      if (jobByRunner) return jobByRunner;
-    }
-
-    const inProgress = matrixJobs.find((j) => j.status === 'in_progress');
-    if (inProgress) return inProgress;
-
-    return matrixJobs.sort((a, b) => {
-      const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
-      const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
-      return bTime - aTime;
-    })[0];
-  }
-
-  // Fallback — may pick the wrong job in multi-job workflows
   const job = jobs[0];
   if (!job) throw new Error('No jobs found for this workflow run');
   core.warning(`Could not match job name "${currentJobName}", falling back to "${job.name}"`);

--- a/otel-export/test/collector.test.ts
+++ b/otel-export/test/collector.test.ts
@@ -20,57 +20,69 @@ function makeJob(overrides: Record<string, unknown> = {}) {
 }
 
 describe('findCurrentJob', () => {
-  it('returns exact name match', () => {
-    const jobs = [makeJob({ name: 'build' }), makeJob({ name: 'test' })];
-    expect(findCurrentJob(jobs, 'build').name).toBe('build');
-  });
-
-  it('matches single matrix job by prefix', () => {
-    const jobs = [makeJob({ name: 'build (images/go)' })];
-    expect(findCurrentJob(jobs, 'build').name).toBe('build (images/go)');
-  });
-
-  it('matches matrix job by RUNNER_NAME when multiple candidates exist', () => {
+  function withRunner(name: string, fn: () => void) {
     const saved = process.env.RUNNER_NAME;
     try {
-      process.env.RUNNER_NAME = 'runner-2';
-      const jobs = [
-        makeJob({ name: 'build (images/go)', runner_name: 'runner-1' }),
-        makeJob({ name: 'build (images/redis)', runner_name: 'runner-2' }),
-      ];
-      expect(findCurrentJob(jobs, 'build').name).toBe('build (images/redis)');
+      process.env.RUNNER_NAME = name;
+      fn();
     } finally {
       if (saved === undefined) delete process.env.RUNNER_NAME;
       else process.env.RUNNER_NAME = saved;
     }
-  });
+  }
 
-  it('falls back to in_progress job when runner name does not match', () => {
+  function withoutRunner(fn: () => void) {
     const saved = process.env.RUNNER_NAME;
     try {
       delete process.env.RUNNER_NAME;
-      const jobs = [
-        makeJob({ name: 'build (images/go)', status: 'completed' }),
-        makeJob({ name: 'build (images/redis)', status: 'in_progress' }),
-      ];
-      expect(findCurrentJob(jobs, 'build').name).toBe('build (images/redis)');
+      fn();
     } finally {
       if (saved !== undefined) process.env.RUNNER_NAME = saved;
     }
+  }
+
+  it('matches by runner name regardless of job naming', () => {
+    withRunner('runner-3', () => {
+      const jobs = [
+        makeJob({ name: 'skipped', runner_name: null }),
+        makeJob({ name: 'caller / inner', runner_name: 'runner-3' }),
+      ];
+      expect(findCurrentJob(jobs, 'wrong-name').name).toBe('caller / inner');
+    });
   });
 
-  it('falls back to most recently started job', () => {
-    const saved = process.env.RUNNER_NAME;
-    try {
-      delete process.env.RUNNER_NAME;
+  it('handles matrix jobs via runner name', () => {
+    withRunner('runner-2', () => {
       const jobs = [
-        makeJob({ name: 'build (images/go)', status: 'completed', started_at: '2024-01-01T00:00:00Z' }),
-        makeJob({ name: 'build (images/redis)', status: 'completed', started_at: '2024-01-01T00:05:00Z' }),
+        makeJob({ name: 'build (a)', runner_name: 'runner-1' }),
+        makeJob({ name: 'build (b)', runner_name: 'runner-2' }),
       ];
-      expect(findCurrentJob(jobs, 'build').name).toBe('build (images/redis)');
-    } finally {
-      if (saved !== undefined) process.env.RUNNER_NAME = saved;
-    }
+      expect(findCurrentJob(jobs, 'build').name).toBe('build (b)');
+    });
+  });
+
+  it('handles reusable workflows via runner name', () => {
+    withRunner('runner-5', () => {
+      const jobs = [
+        makeJob({ name: 'other', runner_name: null, conclusion: 'skipped' }),
+        makeJob({ name: 'caller / inner', runner_name: 'runner-5' }),
+      ];
+      expect(findCurrentJob(jobs, 'inner').name).toBe('caller / inner');
+    });
+  });
+
+  it('falls back to exact name match without runner name', () => {
+    withoutRunner(() => {
+      const jobs = [makeJob({ name: 'build' }), makeJob({ name: 'test' })];
+      expect(findCurrentJob(jobs, 'build').name).toBe('build');
+    });
+  });
+
+  it('falls back to matrix prefix match without runner name', () => {
+    withoutRunner(() => {
+      const jobs = [makeJob({ name: 'build (variant-a)' })];
+      expect(findCurrentJob(jobs, 'build').name).toBe('build (variant-a)');
+    });
   });
 
   it('throws when no jobs exist', () => {


### PR DESCRIPTION
use the `RUNNER_NAME` for the current job instead of trying to piece it together