### PR TITLE
fix(setup-knative): make resource_blaster fail loudly on HTTP errors

### DIFF
--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -106,7 +106,11 @@ runs:
             REAL_KNATIVE_VERSION="knative-v${{ inputs.version }}"
           fi
 
-          curl -L -s "https://github.com/knative/${REPO}/releases/download/${REAL_KNATIVE_VERSION}/${FILE}" \
+          # -f makes curl fail on HTTP errors instead of piping an error body
+          # into yq, where it would surface as a confusing YAML parse error.
+          # --retry rides out transient GitHub release-asset blips.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/knative/${REPO}/releases/download/${REAL_KNATIVE_VERSION}/${FILE}" \
             | yq e 'del(.spec.template.spec.containers[]?.resources)' - \
             `# Filter out empty objects that come out as {} b/c kubectl barfs` \
             | grep -v '^{}$'


### PR DESCRIPTION
## What

Make the `curl` in `setup-knative`'s `resource_blaster` fail fast and clearly on HTTP errors.

## Why

When GitHub returns a non-2xx for a Knative release asset (occasional release-asset blips, Pages-style 5xx, an unexpected redirect), the previous `curl -L -s` silently piped the HTML/text error body into `yq`. The failure surfaced much later as a confusing YAML parse error from `kubectl apply -f -`, sending whoever was debugging into the wrong neighborhood.

`-f` makes `curl` exit non-zero on HTTP errors instead, and `--retry 5 --retry-all-errors --retry-delay 2` rides out transient blips before failing. `-S` keeps errors visible despite `-s`.

## Notes

- Step runs under GitHub Actions' default `set -eo pipefail`, so a non-zero `curl` aborts the pipeline rather than letting `yq`/`kubectl` see an empty/garbage stream.
- `--retry-all-errors` requires curl 7.71+, available on all current GitHub-hosted runner images.
- `download_istioctl` further down uses `wget`, which already fails on non-2xx by default — left untouched.