### PR TITLE
setup-kind: add enable-kvm option to mount /dev/kvm into workers.

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -148,3 +148,70 @@ jobs:
       uses: chainguard-dev/actions/kind-diag@c69a264ec2a5934c3186c618f368fc1c86f16cff # v1.6.19
       with:
         artifact-name: logs.${{ matrix.k8s-version }}
+
+  test-enable-kvm:
+    name: test enable-kvm
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+        allowed-endpoints: >
+          *.blob.core.windows.net:443
+          api.github.com:443
+          cdn01.quay.io:443
+          github.com:443
+          mirror.gcr.io:443
+          packages.wolfi.dev:443
+          production.cloudflare.docker.com:443
+          quay.io:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          release-assets.githubusercontent.com:443
+
+    - name: Checkout the current action
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    # Open /dev/kvm up to docker on the runner so the bind-mount that
+    # setup-kind's enable-kvm performs has something to surface.
+    # ref: https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+    - name: Enable KVM access on the runner
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        ls -la /dev/kvm
+
+    - name: setup-kind (enable-kvm)
+      uses: ./setup-kind
+      with:
+        k8s-version: 1.33.x
+        enable-kvm: true
+
+    # Confirm the bind-mount happened on the worker but NOT the
+    # control plane.
+    - name: Verify /dev/kvm presence per node role
+      run: |
+        if ! docker exec kind-worker test -c /dev/kvm; then
+          echo "kind-worker is missing /dev/kvm"
+          exit 1
+        fi
+        echo "kind-worker has /dev/kvm"
+
+        if docker exec kind-control-plane test -c /dev/kvm 2>/dev/null; then
+          echo "kind-control-plane unexpectedly has /dev/kvm"
+          exit 1
+        fi
+        echo "kind-control-plane correctly does not have /dev/kvm"
+
+    - name: Collect diagnostics
+      if: ${{ failure() }}
+      uses: chainguard-dev/actions/kind-diag@c69a264ec2a5934c3186c618f368fc1c86f16cff # v1.6.19
+      with:
+        artifact-name: logs.enable-kvm

--- a/setup-kind/README.md
+++ b/setup-kind/README.md
@@ -33,6 +33,13 @@ This action spins up a KinD cluster with a handful of useful knobs exposed.
     # For example, InPlacePodVerticalScaling,HPAScaleToZero.
     # Optional.
     feature-gates: InPlacePodVerticalScaling,HPAScaleToZero
+    # Enable KVM bind-mounts /dev/kvm into each KinD worker node
+    # container so pods scheduled there can use KVM-accelerated QEMU.
+    # The host's /dev/kvm must already be readable/writable by docker
+    # (typically via a udev rule the workflow installs before this
+    # step).
+    # Optional, defaults to false.
+    enable-kvm: false
 ```
 
 ## Scenarios

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -73,6 +73,23 @@ inputs:
     required: false
     default: ""
 
+  enable-kvm:
+    description: |
+      When set to "true", bind-mount /dev/kvm from the host into each
+      KinD worker node container so pods scheduled there can use it
+      (e.g. to run QEMU with KVM acceleration).
+
+      Requires that /dev/kvm exists and is accessible to the docker
+      daemon on the host (typically the workflow installs a udev rule
+      that opens the device up — see the comment in
+      https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/).
+      A device-plugin advertising the resource (e.g.
+      generic-device-plugin with --domain set) is what makes /dev/kvm
+      available to pods that request it — this action only handles
+      surfacing the device into the worker nodes.
+    required: false
+    default: "false"
+
 outputs:
   kind-start-time:
     description: |
@@ -157,6 +174,7 @@ runs:
         INPUTS_SERVICE_ACCOUNT_ISSUER: ${{ inputs.service-account-issuer }}
         INPUTS_CLUSTER_SUFFIX: ${{ inputs.cluster-suffix }}
         INPUTS_FEATURE_GATES: ${{ inputs.feature-gates }}
+        INPUTS_ENABLE_KVM: ${{ inputs.enable-kvm }}
       shell: bash
       run: |
         cat > kind.yaml <<EOF
@@ -172,10 +190,20 @@ runs:
 
         if [ "${INPUTS_KIND_WORKER_COUNT}" -ne 0 ]; then
           for node in $(seq 1 "${INPUTS_KIND_WORKER_COUNT}"); do
-          cat >> kind.yaml <<EOF
+            cat >> kind.yaml <<EOF
         - role: worker
           image: "${KIND_IMAGE}"
         EOF
+            # When enable-kvm=true, surface /dev/kvm from the host into
+            # the worker node container so pods scheduled here can use
+            # KVM-accelerated QEMU.
+            if [[ "${INPUTS_ENABLE_KVM}" == "true" ]]; then
+              cat >> kind.yaml <<EOF
+          extraMounts:
+          - containerPath: /dev/kvm
+            hostPath: /dev/kvm
+        EOF
+            fi
           done
         fi
 


### PR DESCRIPTION
When set to true, /dev/kvm from the host is bind-mounted into each KinD worker node container so pods scheduled there can run QEMU with KVM acceleration. The control plane is intentionally untouched.

The host's /dev/kvm still has to be docker-accessible (typically via a udev rule the workflow installs before this step), and a device- plugin (e.g. generic-device-plugin) is what actually advertises the resource to the scheduler. This action only handles surfacing the device into the worker nodes.

Defaults to false, so existing callers are unaffected.