### PR TITLE
test-setup-kind: add explicit kvm-available and kvm-unavailable legs.

### DIFF
--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -148,3 +148,138 @@ jobs:
       uses: chainguard-dev/actions/kind-diag@c69a264ec2a5934c3186c618f368fc1c86f16cff # v1.6.19
       with:
         artifact-name: logs.${{ matrix.k8s-version }}
+
+  # KinD nodes run as --privileged docker containers, which means
+  # /dev/kvm is surfaced from the host into the node container when
+  # the host exposes it. The two jobs below pin both halves of that
+  # invariant on the runner pools that exercise each path.
+
+  test-kvm-available:
+    # ubuntu-latest is x86_64 hosted; /dev/kvm is present on these
+    # runners (we just need a udev rule to open the perms).
+    name: test kvm available
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+        allowed-endpoints: >
+          *.blob.core.windows.net:443
+          api.github.com:443
+          cdn01.quay.io:443
+          github.com:443
+          mirror.gcr.io:443
+          packages.wolfi.dev:443
+          production.cloudflare.docker.com:443
+          quay.io:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          release-assets.githubusercontent.com:443
+
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    # ref: https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+    - name: Open /dev/kvm permissions on host
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Assert /dev/kvm present on host
+      run: |
+        if [ ! -c /dev/kvm ]; then
+          echo "expected /dev/kvm on the host, got none"
+          exit 1
+        fi
+        ls -la /dev/kvm
+
+    - name: setup-kind
+      uses: ./setup-kind
+      with:
+        k8s-version: 1.33.x
+
+    - name: Assert /dev/kvm present in every kind node
+      run: |
+        for node in $(kind get nodes); do
+          if ! docker exec "${node}" test -c /dev/kvm; then
+            echo "expected /dev/kvm in ${node}, got none"
+            exit 1
+          fi
+          echo "OK: ${node} has /dev/kvm"
+        done
+
+    - name: Collect diagnostics
+      if: ${{ failure() }}
+      uses: chainguard-dev/actions/kind-diag@c69a264ec2a5934c3186c618f368fc1c86f16cff # v1.6.19
+      with:
+        artifact-name: logs.kvm-available
+
+  test-kvm-unavailable:
+    # ubuntu-24.04-arm is aarch64 hosted; these runners do not ship
+    # /dev/kvm. If that changes in the future this test will start
+    # failing in the assertion below, which is exactly the regression
+    # signal we want.
+    name: test kvm unavailable
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+        allowed-endpoints: >
+          *.blob.core.windows.net:443
+          api.github.com:443
+          cdn01.quay.io:443
+          github.com:443
+          mirror.gcr.io:443
+          packages.wolfi.dev:443
+          production.cloudflare.docker.com:443
+          quay.io:443
+          raw.githubusercontent.com:443
+          registry-1.docker.io:443
+          release-assets.githubusercontent.com:443
+
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Assert /dev/kvm absent on host
+      run: |
+        if [ -e /dev/kvm ]; then
+          echo "expected no /dev/kvm on the host, got one:"
+          ls -la /dev/kvm
+          exit 1
+        fi
+        echo "OK: /dev/kvm absent on host"
+
+    - name: setup-kind
+      uses: ./setup-kind
+      with:
+        k8s-version: 1.33.x
+
+    - name: Assert /dev/kvm absent from every kind node
+      run: |
+        for node in $(kind get nodes); do
+          if docker exec "${node}" test -e /dev/kvm 2>/dev/null; then
+            echo "expected no /dev/kvm in ${node}, got one"
+            exit 1
+          fi
+          echo "OK: ${node} has no /dev/kvm"
+        done
+
+    - name: Collect diagnostics
+      if: ${{ failure() }}
+      uses: chainguard-dev/actions/kind-diag@c69a264ec2a5934c3186c618f368fc1c86f16cff # v1.6.19
+      with:
+        artifact-name: logs.kvm-unavailable


### PR DESCRIPTION
KinD nodes run as --privileged docker containers, which surfaces /dev/kvm from the host into the node container when the host exposes it. Two new jobs pin both halves of that invariant on the runner pools that exercise each path:

  test-kvm-available   (ubuntu-latest, x86_64) — asserts /dev/kvm
    is present on the host (after a udev rule to open perms) and
    present in every kind node container.

  test-kvm-unavailable (ubuntu-24.04-arm)      — asserts /dev/kvm
    is absent on the host and absent from every kind node
    container.

If either runner image changes such that /dev/kvm appears (or disappears) unexpectedly, the corresponding job fails — exactly the regression signal we want, since microvm-style workloads on kind depend on this passthrough behavior.