### PR TITLE
Bump major tool defaults (helm, argo, istio, knative, k8s) + add CI coverage + dependabot npm/gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
     directories:
       # / covers .github/workflows
       - "/"
@@ -36,3 +38,19 @@ updates:
       - "/wgetsum"
       - "/whereami"
       - "/wolfi-build-pkg"
+
+  - package-ecosystem: "npm"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/otel-export"
+
+  - package-ecosystem: "gomod"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3
+    directories:
+      - "/hugo2confluence"

--- a/.github/workflows/test-setup-hakn.yaml
+++ b/.github/workflows/test-setup-hakn.yaml
@@ -1,0 +1,49 @@
+name: test-setup-hakn
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'setup-hakn/**'
+      - '.github/workflows/test-setup-hakn.yaml'
+
+concurrency:
+  group: test-setup-hakn-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test_setup_hakn:
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: read
+
+    name: Install hakn (Knative + Istio) and verify it comes up
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # TODO(harden-runner): switch to block once IPv6 multicast (ff02::1) is supported (kind uses Docker container networking)
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: setup-kind
+        uses: ./setup-kind
+
+      - name: setup-hakn
+        uses: ./setup-hakn
+
+      - name: Check install!
+        run: |
+          kubectl get pods -n knative-serving
+          kubectl get pods -n istio-system
+          kubectl wait -n knative-serving --timeout=5m --for=condition=ready pods --all
+
+      - name: Collect diagnostics
+        if: ${{ failure() }}
+        uses: chainguard-dev/actions/kind-diag@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23

--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -44,13 +44,13 @@ jobs:
 
         include:
         - k8s-version: 1.33.x
-          knative-version: 1.17.0
+          knative-version: 1.20.3
         - k8s-version: 1.34.x
-          knative-version: 1.19.0
+          knative-version: 1.21.3
         - k8s-version: 1.35.x
-          knative-version: 1.20.0
+          knative-version: 1.22.1
         - k8s-version: 1.36.x
-          knative-version: 1.20.0
+          knative-version: 1.22.1
 
     permissions:
       contents: read

--- a/.github/workflows/test-setup-kind.yaml
+++ b/.github/workflows/test-setup-kind.yaml
@@ -43,10 +43,12 @@ jobs:
         - potato.local
 
         include:
+        # Knative installs multiple components with one version, so only fully
+        # coordinated releases work; Knative >= 1.22 also requires k8s >= 1.34.
         - k8s-version: 1.33.x
-          knative-version: 1.20.3
+          knative-version: 1.17.0
         - k8s-version: 1.34.x
-          knative-version: 1.21.3
+          knative-version: 1.19.0
         - k8s-version: 1.35.x
           knative-version: 1.22.1
         - k8s-version: 1.36.x

--- a/.github/workflows/test-setup-knative-eventing.yaml
+++ b/.github/workflows/test-setup-knative-eventing.yaml
@@ -1,0 +1,50 @@
+name: test-setup-knative-eventing
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'setup-knative-eventing/**'
+      - '.github/workflows/test-setup-knative-eventing.yaml'
+
+concurrency:
+  group: test-setup-knative-eventing-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test_setup_knative_eventing:
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: read
+
+    name: Install Knative Eventing and verify it comes up
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # TODO(harden-runner): switch to block once IPv6 multicast (ff02::1) is supported (kind uses Docker container networking)
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: setup-kind
+        uses: ./setup-kind
+
+      - name: setup-knative-eventing
+        uses: ./setup-knative-eventing
+
+      - name: Check install!
+        run: |
+          kubectl get pods -n knative-eventing
+          for x in $(kubectl get deploy --namespace knative-eventing -oname); do
+            kubectl rollout status --timeout 5m --namespace knative-eventing "$x"
+          done
+
+      - name: Collect diagnostics
+        if: ${{ failure() }}
+        uses: chainguard-dev/actions/kind-diag@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23

--- a/.github/workflows/test-setup-knative-eventing.yaml
+++ b/.github/workflows/test-setup-knative-eventing.yaml
@@ -34,6 +34,9 @@ jobs:
 
       - name: setup-kind
         uses: ./setup-kind
+        with:
+          # Knative Eventing >= 1.22 requires Kubernetes >= 1.34.
+          k8s-version: 1.35.x
 
       - name: setup-knative-eventing
         uses: ./setup-knative-eventing

--- a/.github/workflows/test-setup-monitoring.yaml
+++ b/.github/workflows/test-setup-monitoring.yaml
@@ -1,0 +1,50 @@
+name: test-setup-monitoring
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'setup-monitoring/**'
+      - '.github/workflows/test-setup-monitoring.yaml'
+
+concurrency:
+  group: test-setup-monitoring-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test_setup_monitoring:
+    runs-on: 'ubuntu-latest'
+
+    permissions:
+      contents: read
+
+    name: Install monitoring stack and verify it comes up
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # TODO(harden-runner): switch to block once IPv6 multicast (ff02::1) is supported (kind uses Docker container networking)
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: setup-kind
+        uses: ./setup-kind
+
+      - name: setup-monitoring
+        uses: ./setup-monitoring
+
+      - name: Check install!
+        run: |
+          helm status prometheus -n monitoring-system
+          kubectl get pods -n monitoring-system
+          kubectl wait --for=condition=ready pod \
+            --all -n monitoring-system --timeout=5m
+
+      - name: Collect diagnostics
+        if: ${{ failure() }}
+        uses: chainguard-dev/actions/kind-diag@5f020827ba80ff5d64d45116542d0c733e8e7e71 # v1.6.23

--- a/.github/workflows/test-setup-monitoring.yaml
+++ b/.github/workflows/test-setup-monitoring.yaml
@@ -51,10 +51,13 @@ jobs:
         run: |
           kubectl get pods -n monitoring-system -o wide || true
           kubectl get events -n monitoring-system --sort-by=.lastTimestamp | tail -40 || true
-          for p in $(kubectl get pods -n monitoring-system \
-            --field-selector=status.phase!=Running -o name 2>/dev/null); do
-            echo "::group:: describe $p"
+          # Note: a CrashLoopBackOff pod still has phase=Running, so describe
+          # and log every pod rather than filtering on phase.
+          for p in $(kubectl get pods -n monitoring-system -o name 2>/dev/null); do
+            echo "::group:: $p"
             kubectl describe -n monitoring-system "$p" || true
+            kubectl logs -n monitoring-system "$p" --all-containers --tail=50 --previous 2>/dev/null \
+              || kubectl logs -n monitoring-system "$p" --all-containers --tail=50 || true
             echo "::endgroup::"
           done
 

--- a/.github/workflows/test-setup-monitoring.yaml
+++ b/.github/workflows/test-setup-monitoring.yaml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   test_setup_monitoring:
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 25
 
     permissions:
       contents: read
@@ -44,6 +45,18 @@ jobs:
           kubectl get pods -n monitoring-system
           kubectl wait --for=condition=ready pod \
             --all -n monitoring-system --timeout=5m
+
+      - name: Dump monitoring namespace on failure
+        if: ${{ failure() }}
+        run: |
+          kubectl get pods -n monitoring-system -o wide || true
+          kubectl get events -n monitoring-system --sort-by=.lastTimestamp | tail -40 || true
+          for p in $(kubectl get pods -n monitoring-system \
+            --field-selector=status.phase!=Running -o name 2>/dev/null); do
+            echo "::group:: describe $p"
+            kubectl describe -n monitoring-system "$p" || true
+            echo "::endgroup::"
+          done
 
       - name: Collect diagnostics
         if: ${{ failure() }}

--- a/setup-argo-workflows/action.yaml
+++ b/setup-argo-workflows/action.yaml
@@ -10,9 +10,9 @@ inputs:
 
   argo-version:
     description: |
-      The version of Argo Workflows to use in the form: 3.6.10
+      The version of Argo Workflows to use in the form: 4.0.6
     required: true
-    default: 3.6.10
+    default: 4.0.6
   install-argo-cli-only:
     description: |
       If true, only the Argo CLI will be installed, and the Argo Workflows

--- a/setup-argo-workflows/action.yaml
+++ b/setup-argo-workflows/action.yaml
@@ -31,7 +31,9 @@ runs:
       shell: bash
       run: |
         kubectl create namespace argo
-        kubectl apply -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/v${INPUTS_ARGO_VERSION}/install.yaml"
+        # Use server-side apply: as of v4.x the Argo CRDs exceed the 262144-byte
+        # limit on the client-side "last-applied-configuration" annotation.
+        kubectl apply --server-side -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/v${INPUTS_ARGO_VERSION}/install.yaml"
 
     - name: Install cosign to validate argo-cli binaries
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/setup-hakn/action.yaml
+++ b/setup-hakn/action.yaml
@@ -9,15 +9,15 @@ description: |
 inputs:
   version:
     description: |
-      The version of Hakn to install, e.g. 1.11.0
+      The version of Hakn to install, e.g. 1.12.2
     required: false
-    default: 1.11.0
+    default: 1.12.2
 
   istio-version:
     description: |
-      The version of Istio to install, e.g. 1.17.5
+      The version of Istio to install, e.g. 1.30.1
     required: false
-    default: 1.17.5
+    default: 1.30.1
 
   enable-auto-injection:
     description: |

--- a/setup-kind/action.yaml
+++ b/setup-kind/action.yaml
@@ -15,9 +15,9 @@ inputs:
 
   k8s-version:
     description: |
-      The version of Kubernetes to use in the form: 1.33.x
+      The version of Kubernetes to use in the form: 1.34.x
     required: true
-    default: 1.33.x
+    default: 1.34.x
 
   kind-version:
     description: |

--- a/setup-knative-eventing/action.yaml
+++ b/setup-knative-eventing/action.yaml
@@ -9,9 +9,9 @@ description: |
 inputs:
   version:
     description: |
-      The version of Knative to install, e.g. 1.11.0
+      The version of Knative to install, e.g. 1.22.2
     required: false
-    default: 1.11.0
+    default: 1.22.2
 
 runs:
   using: "composite"

--- a/setup-knative/action.yaml
+++ b/setup-knative/action.yaml
@@ -13,7 +13,7 @@ inputs:
       Knative, the components are out of sync, so to work around that you can
       specify "latest" and it will fetch the latest ones for all the components.
     required: true
-    default: 1.15.0
+    default: 1.22.1
 
   serving-version:
     description: |
@@ -29,9 +29,9 @@ inputs:
 
   istio-version:
     description: |
-      The version of Istio to install, e.g. 1.17.5
+      The version of Istio to install, e.g. 1.30.1
     required: false
-    default: 1.17.5
+    default: 1.30.1
 
   kingress:
     description: |

--- a/setup-monitoring/action.yaml
+++ b/setup-monitoring/action.yaml
@@ -46,5 +46,8 @@ runs:
           --create-namespace -n "${INPUTS_MONITORING_NAMESPACE}" \
           -f "$GITHUB_ACTION_PATH/values.yaml" \
           --version "${INPUTS_PROMETHEUS_CHART_VERSION}" \
-          --wait \
+          `# Helm 4 made --wait a WaitStrategy; bare --wait selects the new` \
+          `# "watcher" strategy which ignores --timeout, so request the` \
+          `# Helm 3-equivalent "legacy" strategy explicitly.` \
+          --wait=legacy \
           --timeout 10m

--- a/setup-monitoring/action.yaml
+++ b/setup-monitoring/action.yaml
@@ -46,4 +46,5 @@ runs:
           --create-namespace -n "${INPUTS_MONITORING_NAMESPACE}" \
           -f "$GITHUB_ACTION_PATH/values.yaml" \
           --version "${INPUTS_PROMETHEUS_CHART_VERSION}" \
-          --wait
+          --wait \
+          --timeout 10m

--- a/setup-monitoring/action.yaml
+++ b/setup-monitoring/action.yaml
@@ -9,15 +9,15 @@ description: |
 inputs:
   helm-version:
     description: |
-      Helm version to install (default v3.19.0)
+      Helm version to install (default v4.2.1)
     required: false
-    default: v3.19.0
+    default: v4.2.1
 
   prometheus-chart-version:
     description: |
-      kube-prometheus-stack helm chart version to be installed (default 34.5.1)
+      kube-prometheus-stack helm chart version to be installed (default 86.2.3)
     required: false
-    default: 34.5.1
+    default: 86.2.3
 
   monitoring-namespace:
     description: |

--- a/setup-monitoring/values.yaml
+++ b/setup-monitoring/values.yaml
@@ -11,12 +11,17 @@ grafana:
   sidecar:
     dashboards:
       searchNamespace: ALL
-  plugins:
-    enabled: true
   plugins: []
   extraContainers: |
     - name: renderer
       image: docker.io/grafana/grafana-image-renderer:3.4.2
+      env:
+        - name: AUTH_TOKEN
+          value: monitoring-renderer-token
   env:
     GF_RENDERING_SERVER_URL: http://localhost:8081/render
     GF_RENDERING_CALLBACK_URL: http://localhost:3000/
+    # Modern Grafana refuses to start when an external renderer is configured
+    # and the renderer token is left at its default. Set a non-default value
+    # that matches the renderer container's AUTH_TOKEN above.
+    GF_RENDERING_RENDERER_TOKEN: monitoring-renderer-token


### PR DESCRIPTION
## What

Follow-up to #954, covering the major-version jumps held back from that PR, plus new CI coverage and a Dependabot gap. One commit per logical change.

### Tool / default version bumps
| Action | Change |
|--------|--------|
| `setup-argo-workflows` | Argo Workflows default `3.6.10` → `4.0.6` |
| `setup-monitoring` | Helm `3.19.0` → `4.2.1`, kube-prometheus-stack `34.5.1` → `86.2.3` |
| `setup-knative` | Knative default `1.15.0` → `1.22.1`, Istio `1.17.5` → `1.30.1` |
| `setup-knative-eventing` | Knative Eventing default `1.11.0` → `1.22.2` |
| `setup-hakn` | Hakn `1.11.0` → `1.12.2`, Istio `1.17.5` → `1.30.1` |
| `setup-kind` | Default Kubernetes `1.33.x` → `1.34.x` (see below) |

### Fixes uncovered by the new CI
- **`setup-argo-workflows`**: Argo v4 CRDs exceed the 262144-byte client-side-apply annotation limit, so the install now uses `kubectl apply --server-side`.
- **`setup-kind` default k8s → 1.34.x**: Knative ≥ 1.22 requires Kubernetes ≥ 1.34. Bumping the setup-kind default keeps the default action set composable out of the box (both versions are supported by setup-kind).

### New CI coverage
- Added `test-setup-monitoring`, `test-setup-knative-eventing`, and `test-setup-hakn` (KinD-based smoke tests) — previously only argo and knative had coverage among the bumped actions.
- Updated the `test-setup-kind` knative matrix to exercise the new 1.22.1 line. Note: the knative install pulls several components under one version, so only fully **coordinated** releases resolve (uncoordinated patch versions 404); matrix versions are pinned to CI-validated combos, and knative ≥ 1.22 legs run on k8s ≥ 1.34.

### Dependabot
- `dependabot.yml` now tracks **npm** (`otel-export`) and **gomod** (`hugo2confluence`); previously only `github-actions` was covered. A 3-day `cooldown` was added to every ecosystem to satisfy the repo's configured zizmor `dependabot-cooldown` rule (also clears a pre-existing warning on the github-actions entry).

## Testing
- New KinD tests for monitoring (Helm 4 + chart 86), knative-eventing (1.22.2), and hakn (Knative + Istio 1.30.1) all run on this PR.
- Argo install verified after the server-side-apply fix.
- All workflows pass `zizmor --persona pedantic` and Action lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)