### PR TITLE
fix(nodiff): generate patch from the checkout dir, not workspace root

### DIFF
--- a/nodiff/action.yaml
+++ b/nodiff/action.yaml
@@ -70,8 +70,13 @@ runs:
     - name: Generate patch
       if: failure()
       shell: bash
+      # Run git inside the checkout (honoring inputs.path), since the repo may
+      # live in a subdirectory of the workspace (e.g. a GOPATH-style layout).
+      # Write the patch to the workspace root so the upload step's relative
+      # path resolves regardless of where the repo was checked out.
+      working-directory: ${{ github.workspace }}/${{ inputs.path }}
       run: |
-        git diff HEAD > diff.patch
+        git diff HEAD > "${GITHUB_WORKSPACE}/diff.patch"
     - name: Upload patch
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What

Make `nodiff`'s failure-path patch generation honor the `path` input so it works when a repo is checked out into a subdirectory of the workspace.

## Why

With a subdirectory checkout (e.g. a GOPATH-style layout via `path: ./src/github.com/<org>/<repo>`), the `Generate patch` and `Upload patch` steps ran `git diff` at the workspace root, which is not a git repository. On failure — exactly when a contributor needs an actionable patch — the job emitted a confusing `Not a git repository` warning plus git's `--no-index` usage help, and uploaded an empty diff artifact.

Observed in chainguard-dev/mono's Verify Codegen job: https://github.com/chainguard-dev/mono/actions/runs/27700327884/job/81934688074?pr=43074#step:12:323

## Notes

The patch is written to the workspace root so the upload step's relative `path: diff.patch` still resolves for both root and subdirectory checkouts. The verification step and repos checked out at the workspace root (the default empty `path`) are unaffected.