### PR TITLE
fix(ci): allowlist CA revocation endpoints for Windows egress policy

### DIFF
--- a/.github/workflows/test-gitsign.yaml
+++ b/.github/workflows/test-gitsign.yaml
@@ -33,10 +33,20 @@ jobs:
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: block
+        # The sectigo.com/lencr.org entries are the OCSP, CRL and AIA endpoints
+        # named in the certificate chains for github.com (Sectigo) and
+        # release-assets.githubusercontent.com (Let's Encrypt). Windows Schannel
+        # fetches them during the TLS handshake and fails closed when they are
+        # unreachable, so curl exits 35 without them. They are plain HTTP.
         allowed-endpoints: >
           *.blob.core.windows.net:443
+          *.c.lencr.org:80
           *.githubapp.com:443
+          *.i.lencr.org:80
+          crl.sectigo.com:80
+          crt.sectigo.com:80
           github.com:443
+          ocsp.sectigo.com:80
           release-assets.githubusercontent.com:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-terraform-docs.yaml
+++ b/.github/workflows/test-terraform-docs.yaml
@@ -32,10 +32,20 @@ jobs:
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: block
+        # The sectigo.com/lencr.org entries are the OCSP, CRL and AIA endpoints
+        # named in the certificate chains for github.com (Sectigo) and
+        # release-assets.githubusercontent.com (Let's Encrypt). Windows Schannel
+        # fetches them during the TLS handshake and fails closed when they are
+        # unreachable, so curl exits 35 without them. They are plain HTTP.
         allowed-endpoints: >
           *.blob.core.windows.net:443
+          *.c.lencr.org:80
           *.githubapp.com:443
+          *.i.lencr.org:80
+          crl.sectigo.com:80
+          crt.sectigo.com:80
           github.com:443
+          ocsp.sectigo.com:80
           release-assets.githubusercontent.com:443
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Unblocks #993 (`step-security/harden-runner` 2.19.4 → 2.20.0).

## Problem

harden-runner v2.20.0's headline change is *"Support for block policy for MacOS and Windows GitHub-hosted runners"*. On 2.19.4 the Windows agent was effectively a no-op, so `egress-policy: block` only ever constrained Linux and macOS. On 2.20.0 it installs a WFP block-all filter and a DNS proxy.

With enforcement on, the `windows-latest` legs of `test-gitsign` and `test-terraform-docs` fail with a bare `Process completed with exit code 35` — `CURLE_SSL_CONNECT_ERROR`. `curl -sL` swallows the message, which is why the log shows nothing useful.

The harden-runner agent log has the answer:

```
level=INFO msg="blocking DNS query" domain=ocsp.sectigo.com.
level=INFO msg="blocking DNS query" domain=crl.sectigo.com.
level=INFO msg="blocking DNS query" domain=x1.c.lencr.org.
level=INFO msg="blocking DNS query" domain=yr2.c.lencr.org.
```

Those are the CA revocation endpoints named inside the certificate chains being negotiated:

```
$ openssl s_client -connect github.com:443 | openssl x509 -noout -issuer -ext authorityInfoAccess
issuer=C=GB, O=Sectigo Limited, CN=Sectigo Public Server Authentication CA DV E36
Authority Information Access:
    OCSP - URI:http://ocsp.sectigo.com

$ openssl s_client -connect release-assets.githubusercontent.com:443 | openssl x509 -noout -issuer -ext crlDistributionPoints
issuer=C=US, O=Let's Encrypt, CN=YR2
X509v3 CRL Distribution Points: URI:http://yr2.c.lencr.org/30.crl
```

Windows Schannel fetches OCSP/CRL during the TLS handshake and **fails closed** when it can't reach them, so the handshake dies before curl ever gets a byte.

Why only Windows:
- **Linux / macOS** — OpenSSL and LibreSSL don't fetch OCSP or CRLs by default, so nothing is queried.
- **`windows-11-arm`** — passes; the harden-runner Windows agent is amd64-only.

Reproducibility: `windows-latest` has failed on **all four** runs of the 2.20.0 dependabot branch (Jul 10, 13, 16, 29) and passes on every other branch.

## Fix

Add the OCSP, CRL and AIA hosts from those two chains to `allowed-endpoints` in the two workflows that run Windows under `egress-policy: block`. They're plain HTTP, hence port 80.

`crl.sectigo.com` and `ocsp.sectigo.com` and `*.c.lencr.org` were observed blocked in the logs. `crt.sectigo.com` and `*.i.lencr.org` are the AIA *CA Issuers* URIs from the same two certificates — not observed blocked (Schannel had the intermediates cached), added so a chain-building fetch doesn't cause a repeat of this.

These are the only two workflows affected: `test-setup-kind` is the only other one touching Windows and it's already `egress-policy: audit`.

## Verification caveat

Please read this before approving — **CI on this PR does not actually exercise the fix.** `main` still pins harden-runner 2.19.4, where the Windows agent doesn't enforce anything, so these entries are an inert no-op here. Both workflows will go green either way.

The real validation is to merge this, then rebase #993 onto it and confirm the `windows-latest` legs pass. If a CA rotates, the list will need extending — that brittleness is inherent to the allowlist approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)