### PR TITLE
Omit empty sbom-format from Verify invocation

### DIFF
--- a/setup-spdx/action.yaml
+++ b/setup-spdx/action.yaml
@@ -53,4 +53,4 @@ runs:
       INPUTS_SBOM_FORMAT: ${{ inputs.sbom-format }}
     shell: bash
     run: |
-      java -jar "./tools-java-${INPUTS_SPDX_TOOLS_VERSION}-jar-with-dependencies.jar" Verify "${INPUTS_SBOM_PATH}" "${INPUTS_SBOM_FORMAT}"
+      java -jar "./tools-java-${INPUTS_SPDX_TOOLS_VERSION}-jar-with-dependencies.jar" Verify "${INPUTS_SBOM_PATH}" ${INPUTS_SBOM_FORMAT:+"${INPUTS_SBOM_FORMAT}"}


### PR DESCRIPTION
The template-injection hardening in #901 moved the optional sbom-format input into a quoted env var. This turns into an empty string when the input is not set and now the java invocation of thes SPDX fail on all workflows that don't define a value:

```
Invalid file type:
  Process completed with exit code 1.
```
(see for example [this run on the kubernetes org](https://github.com/kubernetes-sigs/bom/actions/runs/32525841302/job/96907552072)) 

The action needs to support omitting the format positional argument to rely on the SPDX tools' format detection.

This PR modifies the invocation to pass the value with `${INPUTS_SBOM_FORMAT:+...}` so the argument is only passed when the input is non-empty.